### PR TITLE
Tighten HAL XHTML CSS spacing and font sizing

### DIFF
--- a/api.hypermedia/src/content_types/hal_xhtml_adapter.ts
+++ b/api.hypermedia/src/content_types/hal_xhtml_adapter.ts
@@ -465,49 +465,50 @@ ${checkboxes}
       * { box-sizing: border-box; }
       body {
         font-family: system-ui, -apple-system, 'Segoe UI', sans-serif;
-        max-width: 1200px;
+        max-width: 860px;
         margin: 0 auto;
         padding: 1rem;
         background: #f5f5f5;
-        line-height: 1.6;
+        line-height: 1.5;
+        font-size: 0.875rem;
         color: #333;
       }
 
       /* HAL Resource Container */
       .hal-resource {
         background: #fff;
-        padding: 2rem;
+        padding: 1.25rem 1.5rem;
         border-radius: 8px;
         box-shadow: 0 1px 3px rgba(0,0,0,0.1);
         margin: 1rem 0;
       }
 
       /* Headings */
-      h1, h2, h3, h4 { color: #333; margin-top: 1.5rem; }
-      h1 { font-size: 2rem; margin-bottom: 1rem; border-bottom: 2px solid #eee; padding-bottom: 0.5rem; }
-      h2 { font-size: 1.5rem; }
+      h1, h2, h3, h4 { color: #333; margin-top: 1rem; }
+      h1 { font-size: 1.5rem; margin-bottom: 1rem; border-bottom: 2px solid #eee; padding-bottom: 0.5rem; }
+      h2 { font-size: 1.2rem; }
       h3 { font-size: 1.25rem; color: #555; }
 
       /* Properties as Definition List */
       dl {
         background: #f5f5f5;
-        padding: 1rem;
+        padding: 0.75rem;
         border-radius: 0.25rem;
         margin: 1rem 0;
       }
       dt {
         font-weight: bold;
-        margin-top: 0.5rem;
+        margin-top: 0.25rem;
         color: #555;
       }
       dd {
-        margin: 0.25rem 0 0.5rem 1rem;
+        margin: 0.1rem 0 0.25rem 0.75rem;
       }
 
       /* Navigation Structure (_nav) */
       .hal-nav {
         margin: 0 0 2rem 0;
-        padding: 1.5rem;
+        padding: 1rem;
         background: #f0f7ff;
         border-radius: 0.5rem;
         border: 1px solid #0066cc;
@@ -573,7 +574,7 @@ ${checkboxes}
 
       /* Embedded Resources */
       .hal-embedded {
-        margin: 2rem 0;
+        margin: 1rem 0;
       }
       .hal-embedded-item {
         margin: 1rem 0;
@@ -585,7 +586,7 @@ ${checkboxes}
 
       /* Navigation Links */
       .hal-links {
-        margin: 1.5rem 0;
+        margin: 1rem 0;
         padding: 1rem 0;
         border-top: 1px solid #eee;
       }
@@ -605,8 +606,8 @@ ${checkboxes}
 
       /* Templates/Forms Section */
       .hal-templates {
-        margin: 2rem 0;
-        padding-top: 2rem;
+        margin: 1rem 0;
+        padding-top: 1rem;
         border-top: 2px solid #0066cc;
       }
       .hal-template {
@@ -624,7 +625,7 @@ ${checkboxes}
       /* Form Elements */
       .hal-template label {
         display: block;
-        margin: 1rem 0 0.25rem 0;
+        margin: 0.5rem 0 0.15rem 0;
         font-weight: 500;
         color: #333;
       }
@@ -634,8 +635,8 @@ ${checkboxes}
         display: block;
         width: 100%;
         max-width: 30rem;
-        padding: 0.75rem;
-        margin: 0.25rem 0 1rem 0;
+        padding: 0.5rem;
+        margin: 0.15rem 0 0.5rem 0;
         border: 1px solid #ccc;
         border-radius: 0.25rem;
         font-family: inherit;
@@ -649,7 +650,7 @@ ${checkboxes}
         box-shadow: 0 0 0 3px rgba(0,102,204,0.1);
       }
       .hal-template button {
-        padding: 0.75rem 1.5rem;
+        padding: 0.5rem 1rem;
         margin: 1rem 0.5rem 0 0;
         background: #0066cc;
         color: white;


### PR DESCRIPTION
## Summary
- Reduced body `max-width` (1200px to 860px), `font-size` (1rem to 0.875rem), and `line-height` (1.6 to 1.5) for a more compact layout
- Shrunk padding, margins, and heading sizes across all HAL sections: resource container, nav, embedded, templates, links, definition lists, and form elements
- CSS-only changes — no HTML structure modifications

## Test plan
- [ ] Verify XHTML responses render correctly in a browser at the new 860px max width
- [ ] Confirm form elements (inputs, textareas, selects, buttons) retain usable sizing with tighter padding
- [ ] Check embedded resources and navigation sections display properly with reduced margins
- [ ] Verify mobile responsive breakpoint still behaves correctly
- [ ] Verify TypeScript compiles cleanly (`npx tsc --noEmit` in `api.hypermedia/`)