### PR TITLE
Add refresh button spin animation (web.shadcn)

### DIFF
--- a/web.shadcn/src/components/hal_collection/hal_collection_list.tsx
+++ b/web.shadcn/src/components/hal_collection/hal_collection_list.tsx
@@ -59,6 +59,8 @@ export interface HalCollectionListProps {
     emptyIcon?: React.ReactNode;
     showCreateButton?: boolean;
     showRefreshButton?: boolean;
+    /** Whether a background refresh is in progress (spins the refresh icon) */
+    refreshing?: boolean;
     className?: string;
     selectableFilter?: (item: HalObject) => boolean;
     getRowClassName?: (item: HalObject) => string;
@@ -109,6 +111,7 @@ export function HalCollectionList({
     emptyIcon,
     showCreateButton = true,
     showRefreshButton = true,
+    refreshing = false,
     className = '',
     selectableFilter,
     getRowClassName,
@@ -274,8 +277,8 @@ export function HalCollectionList({
                         </Button>
                     )}
                     {showRefreshButton && (
-                        <Button variant="outline" size="sm" onClick={handleRefresh}>
-                            <RefreshCw className="mr-2 h-4 w-4" />
+                        <Button variant="outline" size="sm" onClick={handleRefresh} disabled={refreshing}>
+                            <RefreshCw className={`mr-2 h-4 w-4 ${refreshing ? 'animate-spin' : ''}`} />
                             Refresh
                         </Button>
                     )}
@@ -343,8 +346,8 @@ export function HalCollectionList({
                         </Button>
                     )}
                     {showRefreshButton && (
-                        <Button variant="outline" size="sm" onClick={handleRefresh}>
-                            <RefreshCw className="mr-2 h-4 w-4" />
+                        <Button variant="outline" size="sm" onClick={handleRefresh} disabled={refreshing}>
+                            <RefreshCw className={`mr-2 h-4 w-4 ${refreshing ? 'animate-spin' : ''}`} />
                             Refresh
                         </Button>
                     )}

--- a/web.shadcn/src/features/api_keys/components/api_keys_list.tsx
+++ b/web.shadcn/src/features/api_keys/components/api_keys_list.tsx
@@ -24,7 +24,7 @@ import { useConfirmDelete } from '../../../utils/confirm_delete';
 import { useDisclosure } from '../../../hooks/use_disclosure';
 
 export function ApiKeysList() {
-    const { data, loading, error, refresh } = useApiKeys();
+    const { data, loading, refreshing, error, refresh } = useApiKeys();
 
     const [create_modal_opened, { open: open_create_modal, close: close_create_modal }] =
         useDisclosure(false);
@@ -89,6 +89,7 @@ export function ApiKeysList() {
             <HalCollectionList
                 resource={data}
                 onRefresh={refresh}
+                refreshing={refreshing}
                 onCreate={open_create_modal}
                 bulkOperations={[
                     {

--- a/web.shadcn/src/features/api_keys/hooks/use_api_keys.ts
+++ b/web.shadcn/src/features/api_keys/hooks/use_api_keys.ts
@@ -64,6 +64,7 @@ export function useApiKeys() {
     // State
     const [data, setData] = useState<HalObject | null>(null);
     const [loading, setLoading] = useState(true);
+    const [refreshing, setRefreshing] = useState(false);
     const [error, setError] = useState<string | null>(null);
     const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
     const [apiKeysEndpoint, setApiKeysEndpoint] = useState<string | null>(null);
@@ -140,6 +141,7 @@ export function useApiKeys() {
             if (!apiKeysEndpoint) return;
 
             setLoading(true);
+            setRefreshing(data !== null);
             setError(null);
 
             try {
@@ -165,9 +167,10 @@ export function useApiKeys() {
                 setData(null);
             } finally {
                 setLoading(false);
+                setRefreshing(false);
             }
         },
-        [apiKeysEndpoint, pageSize]
+        [apiKeysEndpoint, pageSize, data]
     );
 
     /**
@@ -295,6 +298,7 @@ export function useApiKeys() {
         data,
         apiKeys,
         loading,
+        refreshing,
         error,
         selectedIds,
         pagination,

--- a/web.shadcn/src/features/sessions/components/sessions_list.tsx
+++ b/web.shadcn/src/features/sessions/components/sessions_list.tsx
@@ -32,7 +32,7 @@ import { parseUserAgent } from '../utils/parse_user_agent';
 import type { FieldRenderer } from '@/components/hal_collection';
 
 export function SessionsList() {
-    const { data, sessions, loading, error, refresh } = useSessions();
+    const { data, sessions, loading, refreshing, error, refresh } = useSessions();
 
     // Template execution for bulk delete
     const { execute: execute_bulk_delete } = useExecuteTemplate(() => {
@@ -154,6 +154,7 @@ export function SessionsList() {
         <HalCollectionList
             resource={enhancedData}
             onRefresh={refresh}
+            refreshing={refreshing}
             bulkOperations={[
                 {
                     id: 'delete',

--- a/web.shadcn/src/features/sessions/hooks/use_sessions.ts
+++ b/web.shadcn/src/features/sessions/hooks/use_sessions.ts
@@ -83,6 +83,7 @@ export function useSessions(): UseSessionsResult {
     const [data, setData] = useState<SessionsResponse | null>(null);
     const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
     const [loading, setLoading] = useState(true); // Start with loading true
+    const [refreshing, setRefreshing] = useState(false);
     const [error, setError] = useState<string | null>(null);
     const [sessionsEndpoint, setSessionsEndpoint] = useState<string | null>(null);
     const [hasInitiallyLoaded, setHasInitiallyLoaded] = useState(false); // Track if we've loaded data
@@ -177,6 +178,7 @@ export function useSessions(): UseSessionsResult {
         if (!sessionsEndpoint) return;
 
         setLoading(true);
+        setRefreshing(data !== null);
         setError(null);
 
         try {
@@ -202,8 +204,9 @@ export function useSessions(): UseSessionsResult {
             setData(null);
         } finally {
             setLoading(false);
+            setRefreshing(false);
         }
-    }, [sessionsEndpoint, pageSize]);
+    }, [sessionsEndpoint, pageSize, data]);
 
     /**
      * Handle next page navigation
@@ -321,6 +324,7 @@ export function useSessions(): UseSessionsResult {
         data,
         sessions,
         loading,
+        refreshing,
         error,
         selectedIds,
         currentSessionToken: currentSessionId,

--- a/web.shadcn/src/features/sessions/types.ts
+++ b/web.shadcn/src/features/sessions/types.ts
@@ -80,6 +80,7 @@ export interface UseSessionsResult {
     data: SessionsResponse | null; // Full HAL object with _templates
     sessions: Session[]; // Extracted array for convenience
     loading: boolean;
+    refreshing: boolean;
     error: string | null;
     selectedIds: Set<string>;
     currentSessionToken: string | null;


### PR DESCRIPTION
## Summary
- Add `refreshing` boolean prop to `HalCollectionList` that applies `animate-spin` to the `RefreshCw` icon and disables the Refresh button while a background re-fetch is in progress
- Add `refreshing` state to `use_api_keys` and `use_sessions` hooks — set to `true` only during re-fetches when data already exists (i.e., not on initial load)
- Pass `refreshing` from `ApiKeysList` and `SessionsList` through to `HalCollectionList`

## Behavior
- **Initial load**: `loading=true`, `refreshing=false` — skeleton shown via existing `loading && !data` guard
- **Re-fetch**: `loading=true`, `refreshing=true` — data stays on screen (no skeleton flash), refresh icon spins, button disabled
- No layout shift from the animation (icon dimensions unchanged)

## Files changed
- `hal_collection_list.tsx` — new `refreshing` prop, conditional `animate-spin` class and `disabled` on both Refresh buttons
- `use_api_keys.ts` — `refreshing` state derived from `data !== null` at fetch time
- `use_sessions.ts` — same `refreshing` logic
- `sessions/types.ts` — `refreshing` added to `UseSessionsResult`
- `api_keys_list.tsx` — passes `refreshing` to `HalCollectionList`
- `sessions_list.tsx` — passes `refreshing` to `HalCollectionList`

## Test plan
- [ ] Verify initial page load shows skeleton (no spinner)
- [ ] Click Refresh on API Keys page — icon spins, button disabled, data stays visible, no skeleton flash
- [ ] Click Refresh on Sessions page — same behavior
- [ ] Verify button re-enables and icon stops spinning after fetch completes
- [ ] Verify build succeeds: `cd web.shadcn && npm run build`