### PR TITLE
Add my-profile, help, and help-circle icon mappings

### DIFF
--- a/web.daisyui/src/features/sitemap/utils/icon_mapper.ts
+++ b/web.daisyui/src/features/sitemap/utils/icon_mapper.ts
@@ -14,6 +14,7 @@ import {
     BarChart,
     Circle,
     Clock,
+    HelpCircle,
     LayoutDashboard,
     FileText,
     Gauge,
@@ -44,6 +45,7 @@ export const iconMapper: Record<string, LucideIcon> = {
     // User Management
     users: Users,
     user: UserCircle,
+    'my-profile': UserCircle,
     sessions: UserCircle,
     'user-circle': UserCircle,
 
@@ -77,6 +79,10 @@ export const iconMapper: Record<string, LucideIcon> = {
 
     // API Keys
     'api-keys': Key,
+
+    // Help & Support
+    help: HelpCircle,
+    'help-circle': HelpCircle,
 
     // Default/Unknown
     default: Circle,

--- a/web.mantine/src/features/sitemap/utils/icon_mapper.ts
+++ b/web.mantine/src/features/sitemap/utils/icon_mapper.ts
@@ -17,6 +17,7 @@ import {
     IconDashboard,
     IconFileText,
     IconGauge,
+    IconHelpCircle,
     IconHome,
     IconKey,
     IconLock,
@@ -44,6 +45,7 @@ export const iconMapper: Record<string, Icon> = {
     // User Management
     users: IconUsers,
     user: IconUserCircle,
+    'my-profile': IconUserCircle,
     sessions: IconUserCircle,
     'user-circle': IconUserCircle,
 
@@ -77,6 +79,10 @@ export const iconMapper: Record<string, Icon> = {
 
     // API Keys
     'api-keys': IconKey,
+
+    // Help & Support
+    help: IconHelpCircle,
+    'help-circle': IconHelpCircle,
 
     // Default/Unknown
     default: IconCircle,

--- a/web.shadcn/src/features/sitemap/utils/icon_mapper.ts
+++ b/web.shadcn/src/features/sitemap/utils/icon_mapper.ts
@@ -14,6 +14,7 @@ import {
     BarChart,
     Circle,
     Clock,
+    HelpCircle,
     LayoutDashboard,
     FileText,
     Gauge,
@@ -44,6 +45,7 @@ export const iconMapper: Record<string, LucideIcon> = {
     // User Management
     users: Users,
     user: UserCircle,
+    'my-profile': UserCircle,
     sessions: UserCircle,
     'user-circle': UserCircle,
 
@@ -77,6 +79,10 @@ export const iconMapper: Record<string, LucideIcon> = {
 
     // API Keys
     'api-keys': Key,
+
+    // Help & Support
+    help: HelpCircle,
+    'help-circle': HelpCircle,
 
     // Default/Unknown
     default: Circle,


### PR DESCRIPTION
## Summary
- Adds `'my-profile': UserCircle` mapping to web.shadcn and web.daisyui icon mappers, and `'my-profile': IconUserCircle` to web.mantine
- Adds `'help': HelpCircle` and `'help-circle': HelpCircle` mappings to web.shadcn and web.daisyui, and `'help': IconHelpCircle` / `'help-circle': IconHelpCircle` to web.mantine
- Imports `HelpCircle` (Lucide) and `IconHelpCircle` (Tabler) where missing; `UserCircle` / `IconUserCircle` were already imported

## Test plan
- [x] TypeScript type-check passes (`tsc --noEmit`) in all three modified packages
- [ ] Verify `getIcon('my-profile')` returns the expected UserCircle component
- [ ] Verify `getIcon('help')` and `getIcon('help-circle')` return the expected HelpCircle component
- [ ] Visual verification in each frontend that new icons render correctly