### PR TITLE
Help Center - web.shadcn

### DIFF
--- a/web.shadcn/src/features/dashboard/dashboard.tsx
+++ b/web.shadcn/src/features/dashboard/dashboard.tsx
@@ -6,15 +6,16 @@ import { ScrollArea } from '@/components/ui/scroll-area';
 import { Sheet, SheetContent } from '@/components/ui/sheet';
 import { Skeleton } from '@/components/ui/skeleton';
 import { UserButton } from '@/components/user_button/user_button';
-import WebConfigurationStore from '@/configuration/web_config_store';
 import { useDisclosure } from '@/hooks/use_disclosure';
 import { useHeadroom } from '@/hooks/use_headroom';
 import { cn } from '@/lib/utils';
 import { generateRoutesFromNavStructure } from '@/routing/route_generator';
-import { AlertCircle, ChevronsLeft, ChevronsRight, Code2, HelpCircle, Home, Menu, RefreshCw, Search } from 'lucide-react';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { AlertCircle, ChevronsLeft, ChevronsRight, HelpCircle, Home, Menu, RefreshCw, Search } from 'lucide-react';
+import { useEffect, useMemo, useRef } from 'react';
 import { Route, Routes, useLocation, useNavigate } from 'react-router-dom';
 import { GenericResourceView } from '../resource/generic_resource_view';
+import { HelpPage } from '../help/help_page';
+import { HelpTopicDetail } from '../help/help_topic_detail';
 import { SettingsPage } from '../settings/settings_page';
 import { useSitemap } from '../sitemap/hooks/use_sitemap';
 import { DashboardHome } from './dashboard_home';
@@ -38,7 +39,6 @@ function DashboardContent() {
     const pinned = useHeadroom({ fixedAt: 120 });
     const [mobileOpened, { toggle: toggleMobile }] = useDisclosure(false);
     const [desktopOpened, { toggle: toggleDesktop }] = useDisclosure(true);
-    const [apiBaseUrl, setApiBaseUrl] = useState<string>('');
 
     // Track if this is the initial page load
     const isInitialLoad = useRef(true);
@@ -49,20 +49,16 @@ function DashboardContent() {
         if (isInitialLoad.current) {
             isInitialLoad.current = false;
 
-            // If initial load and not on dashboard, redirect
-            if (location.pathname !== '/dashboard' && location.pathname !== '/') {
+            // If initial load and not on dashboard or help, redirect
+            if (
+                location.pathname !== '/dashboard' &&
+                location.pathname !== '/' &&
+                !location.pathname.startsWith('/help')
+            ) {
                 navigate('/dashboard', { replace: true });
             }
         }
     }, [location.pathname, navigate]);
-
-    // Load API base URL for documentation link
-    useEffect(() => {
-        WebConfigurationStore.getConfig().then((config) => {
-            setApiBaseUrl(config.api.base_url);
-        });
-    }, []);
-
 
     // Generate dynamic routes from sitemap
     const dynamicRoutes = useMemo(() => {
@@ -107,7 +103,6 @@ function DashboardContent() {
         return (
             <>
                 <LinksGroup icon={Home} label="Home" link="/" />
-                {apiBaseUrl && <LinksGroup icon={Code2} label="Hypermedia API Documentation" link={apiBaseUrl} newTab={true} />}
                 {mainNav.map((item) => (
                     <LinksGroup {...item} key={item.label} />
                 ))}
@@ -216,9 +211,9 @@ function DashboardContent() {
                         <Button
                             variant="ghost"
                             size="icon"
-                            disabled
+                            onClick={() => navigate('/help')}
                             aria-label="Help"
-                            title="Help (coming soon)"
+                            title="Help Center"
                         >
                             <HelpCircle className="h-5 w-5" />
                         </Button>
@@ -244,6 +239,10 @@ function DashboardContent() {
 
                                 {/* Client-side routes */}
                                 <Route path="settings" element={<SettingsPage />} />
+
+                                {/* Help Center routes */}
+                                <Route path="help" element={<HelpPage />} />
+                                <Route path="help/:topicId" element={<HelpTopicDetail />} />
 
                                 {/* Dynamic routes from sitemap */}
                                 {dynamicRoutes.map((route, index) => (

--- a/web.shadcn/src/features/help/help_page.tsx
+++ b/web.shadcn/src/features/help/help_page.tsx
@@ -1,0 +1,135 @@
+/**
+ * Help Center Page
+ *
+ * Main landing page for the Help Center feature. Displays a responsive
+ * card grid of help topics and a Tools & Resources section with quick
+ * links to API documentation and API key management.
+ */
+
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { ArrowRight, Code2, Key, LifeBuoy } from 'lucide-react';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import WebConfigurationStore from '@/configuration/web_config_store';
+import { helpTopics } from './help_topic_registry';
+import { useSitemap } from '../sitemap/hooks/use_sitemap';
+
+export const HelpPage = () => {
+    const navigate = useNavigate();
+    const [apiBaseUrl, setApiBaseUrl] = useState<string>('');
+    const { links, templates } = useSitemap();
+
+    useEffect(() => {
+        WebConfigurationStore.getConfig().then((config) => {
+            setApiBaseUrl(config.api.base_url);
+        });
+    }, []);
+
+    // Resolve API keys href from sitemap
+    const apiKeysHref = (() => {
+        if (links && links['api-keys']) return links['api-keys'].href;
+        if (templates && templates['api-keys']) return templates['api-keys'].target;
+        return null;
+    })();
+
+    return (
+        <div className="space-y-8">
+            {/* Page Header */}
+            <div className="space-y-2">
+                <div className="flex items-center gap-3">
+                    <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
+                        <LifeBuoy className="h-5 w-5 text-primary" />
+                    </div>
+                    <h1 className="text-3xl font-bold tracking-tight">Help Center</h1>
+                </div>
+                <p className="text-muted-foreground">
+                    Find guides, references, and answers to common questions.
+                </p>
+            </div>
+
+            {/* Topic Cards Grid */}
+            <div className="grid gap-4 grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
+                {helpTopics.map((topic) => {
+                    const Icon = topic.icon;
+                    return (
+                        <Card
+                            key={topic.id}
+                            className="hover:shadow-md transition-shadow cursor-pointer"
+                            onClick={() => navigate(`/help/${topic.id}`)}
+                        >
+                            <CardHeader>
+                                <div className="flex items-center gap-3">
+                                    <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
+                                        <Icon className="h-5 w-5 text-primary" />
+                                    </div>
+                                    <CardTitle className="text-lg">{topic.title}</CardTitle>
+                                </div>
+                            </CardHeader>
+                            <CardContent>
+                                <CardDescription>{topic.description}</CardDescription>
+                            </CardContent>
+                        </Card>
+                    );
+                })}
+            </div>
+
+            {/* Tools & Resources */}
+            <div>
+                <h2 className="text-2xl font-semibold tracking-tight mb-4">Tools & Resources</h2>
+                <div className="grid gap-4 md:grid-cols-2">
+                    {apiBaseUrl && (
+                        <Card className="hover:shadow-md transition-shadow">
+                            <CardHeader>
+                                <div className="flex items-center gap-3">
+                                    <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
+                                        <Code2 className="h-5 w-5 text-primary" />
+                                    </div>
+                                    <CardTitle className="text-lg">API Documentation</CardTitle>
+                                </div>
+                            </CardHeader>
+                            <CardContent className="space-y-3">
+                                <CardDescription>
+                                    Explore the hypermedia API, endpoints, and response formats.
+                                </CardDescription>
+                                <Button
+                                    className="w-full"
+                                    variant="outline"
+                                    onClick={() => window.open(apiBaseUrl, '_blank', 'noopener,noreferrer')}
+                                >
+                                    Open API Documentation
+                                    <ArrowRight className="ml-2 h-4 w-4" />
+                                </Button>
+                            </CardContent>
+                        </Card>
+                    )}
+
+                    <Card className="hover:shadow-md transition-shadow">
+                        <CardHeader>
+                            <div className="flex items-center gap-3">
+                                <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
+                                    <Key className="h-5 w-5 text-primary" />
+                                </div>
+                                <CardTitle className="text-lg">API Keys</CardTitle>
+                            </div>
+                        </CardHeader>
+                        <CardContent className="space-y-3">
+                            <CardDescription>
+                                Create and manage API keys for programmatic access to your resources.
+                            </CardDescription>
+                            <Button
+                                className="w-full"
+                                variant="outline"
+                                onClick={() => apiKeysHref && navigate(apiKeysHref)}
+                                disabled={!apiKeysHref}
+                            >
+                                Manage API Keys
+                                <ArrowRight className="ml-2 h-4 w-4" />
+                            </Button>
+                        </CardContent>
+                    </Card>
+                </div>
+            </div>
+        </div>
+    );
+};

--- a/web.shadcn/src/features/help/help_topic_detail.tsx
+++ b/web.shadcn/src/features/help/help_topic_detail.tsx
@@ -1,0 +1,47 @@
+/**
+ * Help Topic Detail
+ *
+ * Wrapper component that resolves the topic from the URL parameter
+ * and renders the corresponding content component.
+ */
+
+import { useParams, useNavigate } from 'react-router-dom';
+import { ArrowLeft } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { getHelpTopicById } from './help_topic_registry';
+
+export const HelpTopicDetail = () => {
+    const { topicId } = useParams<{ topicId: string }>();
+    const navigate = useNavigate();
+
+    const topic = topicId ? getHelpTopicById(topicId) : undefined;
+
+    if (!topic) {
+        return (
+            <div className="space-y-6">
+                <Button variant="ghost" onClick={() => navigate('/help')} className="gap-2">
+                    <ArrowLeft className="h-4 w-4" />
+                    Back to Help Center
+                </Button>
+                <div className="text-center py-12">
+                    <h2 className="text-2xl font-semibold tracking-tight">Topic Not Found</h2>
+                    <p className="text-muted-foreground mt-2">
+                        The help topic you are looking for does not exist.
+                    </p>
+                </div>
+            </div>
+        );
+    }
+
+    const TopicContent = topic.component;
+
+    return (
+        <div className="space-y-6">
+            <Button variant="ghost" onClick={() => navigate('/help')} className="gap-2">
+                <ArrowLeft className="h-4 w-4" />
+                Back to Help Center
+            </Button>
+            <TopicContent />
+        </div>
+    );
+};

--- a/web.shadcn/src/features/help/help_topic_registry.tsx
+++ b/web.shadcn/src/features/help/help_topic_registry.tsx
@@ -1,0 +1,85 @@
+/**
+ * Help Topic Registry
+ *
+ * Defines all available help topics with metadata for the Help Center.
+ * Each topic has a URL slug, display metadata, icon, and content component.
+ */
+
+import type { ComponentType } from 'react';
+import type { LucideIcon } from 'lucide-react';
+import { BookOpen, Key, Shield, ShieldCheck, HelpCircle } from 'lucide-react';
+import { GettingStartedContent } from './topics/getting_started';
+import { ApiKeysContent } from './topics/api_keys';
+import { SessionsSecurityContent } from './topics/sessions_security';
+import { AdminContent } from './topics/admin';
+import { FaqContent } from './topics/faq';
+
+/**
+ * Help topic definition
+ */
+export interface HelpTopic {
+    /** URL slug (e.g., "getting-started") */
+    id: string;
+    /** Card title */
+    title: string;
+    /** Card description */
+    description: string;
+    /** Card icon */
+    icon: LucideIcon;
+    /** Detail page content component */
+    component: ComponentType;
+}
+
+/**
+ * Registry of all help topics
+ *
+ * Add new topics here as the application evolves. Each topic appears
+ * as a card on the Help Center page and has a dedicated detail page.
+ */
+export const helpTopics: HelpTopic[] = [
+    {
+        id: 'getting-started',
+        title: 'Getting Started',
+        description: 'Learn the basics of Serverless Launchpad and get up and running quickly.',
+        icon: BookOpen,
+        component: GettingStartedContent,
+    },
+    {
+        id: 'api-keys',
+        title: 'API Keys',
+        description: 'Understand how to create, manage, and use API keys for programmatic access.',
+        icon: Key,
+        component: ApiKeysContent,
+    },
+    {
+        id: 'sessions-security',
+        title: 'Sessions & Security',
+        description: 'Learn about session management, security best practices, and account protection.',
+        icon: Shield,
+        component: SessionsSecurityContent,
+    },
+    {
+        id: 'admin',
+        title: 'Admin',
+        description: 'Administration tools, user management, and system configuration.',
+        icon: ShieldCheck,
+        component: AdminContent,
+    },
+    {
+        id: 'faq',
+        title: 'FAQ',
+        description: 'Frequently asked questions and common troubleshooting tips.',
+        icon: HelpCircle,
+        component: FaqContent,
+    },
+];
+
+/**
+ * Find a help topic by its URL slug
+ *
+ * @param id - Topic URL slug
+ * @returns The matching HelpTopic, or undefined if not found
+ */
+export function getHelpTopicById(id: string): HelpTopic | undefined {
+    return helpTopics.find((topic) => topic.id === id);
+}

--- a/web.shadcn/src/features/help/topics/admin.tsx
+++ b/web.shadcn/src/features/help/topics/admin.tsx
@@ -1,0 +1,20 @@
+/**
+ * Admin Help Topic Content
+ */
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+export const AdminContent = () => {
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle>Admin</CardTitle>
+            </CardHeader>
+            <CardContent>
+                <p className="text-muted-foreground">
+                    This section is a placeholder. Content will be added as the application evolves.
+                </p>
+            </CardContent>
+        </Card>
+    );
+};

--- a/web.shadcn/src/features/help/topics/api_keys.tsx
+++ b/web.shadcn/src/features/help/topics/api_keys.tsx
@@ -1,0 +1,20 @@
+/**
+ * API Keys Help Topic Content
+ */
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+export const ApiKeysContent = () => {
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle>API Keys</CardTitle>
+            </CardHeader>
+            <CardContent>
+                <p className="text-muted-foreground">
+                    This section is a placeholder. Content will be added as the application evolves.
+                </p>
+            </CardContent>
+        </Card>
+    );
+};

--- a/web.shadcn/src/features/help/topics/faq.tsx
+++ b/web.shadcn/src/features/help/topics/faq.tsx
@@ -1,0 +1,20 @@
+/**
+ * FAQ Help Topic Content
+ */
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+export const FaqContent = () => {
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle>FAQ</CardTitle>
+            </CardHeader>
+            <CardContent>
+                <p className="text-muted-foreground">
+                    This section is a placeholder. Content will be added as the application evolves.
+                </p>
+            </CardContent>
+        </Card>
+    );
+};

--- a/web.shadcn/src/features/help/topics/getting_started.tsx
+++ b/web.shadcn/src/features/help/topics/getting_started.tsx
@@ -1,0 +1,20 @@
+/**
+ * Getting Started Help Topic Content
+ */
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+export const GettingStartedContent = () => {
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle>Getting Started</CardTitle>
+            </CardHeader>
+            <CardContent>
+                <p className="text-muted-foreground">
+                    This section is a placeholder. Content will be added as the application evolves.
+                </p>
+            </CardContent>
+        </Card>
+    );
+};

--- a/web.shadcn/src/features/help/topics/sessions_security.tsx
+++ b/web.shadcn/src/features/help/topics/sessions_security.tsx
@@ -1,0 +1,20 @@
+/**
+ * Sessions & Security Help Topic Content
+ */
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+export const SessionsSecurityContent = () => {
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle>Sessions & Security</CardTitle>
+            </CardHeader>
+            <CardContent>
+                <p className="text-muted-foreground">
+                    This section is a placeholder. Content will be added as the application evolves.
+                </p>
+            </CardContent>
+        </Card>
+    );
+};


### PR DESCRIPTION
## Summary
- Add `/help` route with Help Center page featuring a responsive card grid (1 col mobile, 2 tablet, 3 desktop) of 5 placeholder help topics
- Add `/help/:topicId` route that renders topic-specific content components resolved from a centralized registry
- Add Tools & Resources section with links to API Documentation (opens API base URL in new tab) and API Keys management page
- Enable the header Help button to navigate to `/help` and remove the API Documentation link from the sidebar navigation
- Exempt `/help` paths from the HATEOAS initial-load redirect so help pages are directly accessible via URL

## Test plan
- [ ] Verify `/help` renders the Help Center with 5 topic cards in a responsive grid
- [ ] Verify clicking a topic card navigates to `/help/:topicId` and renders the placeholder content
- [ ] Verify the "Back to Help Center" button on topic detail pages returns to `/help`
- [ ] Verify navigating to a nonexistent topic (e.g., `/help/nonexistent`) shows the "Topic Not Found" state
- [ ] Verify the header Help button (question mark icon) navigates to `/help`
- [ ] Verify the API Documentation link is no longer in the sidebar navigation
- [ ] Verify Tools & Resources: API Documentation opens the API base URL in a new tab
- [ ] Verify Tools & Resources: API Keys button navigates to the API keys page
- [ ] Verify the responsive grid: 1 column on mobile, 2 on tablet, 3 on desktop
- [ ] Verify direct URL navigation to `/help` and `/help/:topicId` works (not redirected to dashboard)
- [ ] Verify `cd web.shadcn && npm run build` succeeds