### PR TITLE
add refresh button spin animation for web.mantine

### DIFF
--- a/web.mantine/src/components/hal_collection/hal_collection_list.module.css
+++ b/web.mantine/src/components/hal_collection/hal_collection_list.module.css
@@ -1,0 +1,12 @@
+@keyframes spin {
+    from {
+        transform: rotate(0deg);
+    }
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+.spinning {
+    animation: spin 1s linear infinite;
+}

--- a/web.mantine/src/components/hal_collection/hal_collection_list.tsx
+++ b/web.mantine/src/components/hal_collection/hal_collection_list.tsx
@@ -20,6 +20,7 @@ import { useSelection } from '../../hooks/use_selection';
 import { HalResourceRow } from './hal_resource_row';
 import { type FieldRenderer } from './field_renderers';
 import { type HalObject, type BulkOperation } from '@houseofwolves/serverlesslaunchpad.web.commons';
+import classes from './hal_collection_list.module.css';
 
 export interface HalCollectionListProps {
     resource: HalObject | null | undefined;
@@ -33,6 +34,8 @@ export interface HalCollectionListProps {
     emptyIcon?: React.ReactNode;
     showCreateButton?: boolean;
     showRefreshButton?: boolean;
+    /** Whether a background refresh is in progress (spins the refresh icon) */
+    refreshing?: boolean;
     selectableFilter?: (item: HalObject) => boolean;
     /** Page title to display in the header row */
     title?: string;
@@ -80,6 +83,7 @@ export function HalCollectionList({
     emptyIcon,
     showCreateButton = true,
     showRefreshButton = true,
+    refreshing = false,
     selectableFilter,
     title,
     bulkOperations = [],
@@ -168,7 +172,18 @@ export function HalCollectionList({
                         </Button>
                     )}
                     {showRefreshButton && (
-                        <Button variant="default" size="sm" onClick={handleRefresh} leftSection={<IconRefresh size={16} />}>
+                        <Button
+                            variant="default"
+                            size="sm"
+                            onClick={handleRefresh}
+                            disabled={refreshing}
+                            leftSection={
+                                <IconRefresh
+                                    size={16}
+                                    className={refreshing ? classes.spinning : undefined}
+                                />
+                            }
+                        >
                             Refresh
                         </Button>
                     )}
@@ -236,7 +251,18 @@ export function HalCollectionList({
                         </Button>
                     )}
                     {showRefreshButton && (
-                        <Button variant="default" size="sm" onClick={handleRefresh} leftSection={<IconRefresh size={16} />}>
+                        <Button
+                            variant="default"
+                            size="sm"
+                            onClick={handleRefresh}
+                            disabled={refreshing}
+                            leftSection={
+                                <IconRefresh
+                                    size={16}
+                                    className={refreshing ? classes.spinning : undefined}
+                                />
+                            }
+                        >
                             Refresh
                         </Button>
                     )}

--- a/web.mantine/src/features/api_keys/components/api_keys_list.tsx
+++ b/web.mantine/src/features/api_keys/components/api_keys_list.tsx
@@ -23,7 +23,7 @@ import { confirmDelete } from '../../../utils/confirm_delete';
  * ```
  */
 export function ApiKeysList() {
-    const { data, refresh } = useApiKeys();
+    const { data, refreshing, refresh } = useApiKeys();
 
     const [createModalOpened, { open: openCreateModal, close: closeCreateModal }] =
         useDisclosure(false);
@@ -78,6 +78,7 @@ export function ApiKeysList() {
             <HalCollectionList
                 resource={data}
                 onRefresh={refresh}
+                refreshing={refreshing}
                 onCreate={openCreateModal}
                 bulkOperations={[
                     {

--- a/web.mantine/src/features/api_keys/hooks/use_api_keys.ts
+++ b/web.mantine/src/features/api_keys/hooks/use_api_keys.ts
@@ -38,6 +38,7 @@ export function useApiKeys() {
     // State
     const [data, setData] = useState<HalObject | null>(null);
     const [loading, setLoading] = useState(true);
+    const [refreshing, setRefreshing] = useState(false);
     const [error, setError] = useState<string | null>(null);
     const [apiKeysEndpoint, setApiKeysEndpoint] = useState<string | null>(null);
 
@@ -95,6 +96,7 @@ export function useApiKeys() {
             if (!apiKeysEndpoint) return;
 
             setLoading(true);
+            setRefreshing(data !== null);
             setError(null);
 
             try {
@@ -108,9 +110,10 @@ export function useApiKeys() {
                 setData(null);
             } finally {
                 setLoading(false);
+                setRefreshing(false);
             }
         },
-        [apiKeysEndpoint]
+        [apiKeysEndpoint, data]
     );
 
     /**
@@ -135,6 +138,7 @@ export function useApiKeys() {
     return {
         data,
         loading,
+        refreshing,
         error,
         refresh,
     };

--- a/web.mantine/src/features/sessions/components/sessions_list.tsx
+++ b/web.mantine/src/features/sessions/components/sessions_list.tsx
@@ -29,7 +29,7 @@ import { parseUserAgent } from '../utils/parse_user_agent';
 import type { FieldRenderer } from '../../../components/hal_collection';
 
 export function SessionsList() {
-    const { data, sessions, refresh } = useSessions();
+    const { data, sessions, refreshing, refresh } = useSessions();
 
     // Create enriched resource with isCurrent property on sessions
     const enrichedResource = useMemo(() => {
@@ -129,6 +129,7 @@ export function SessionsList() {
         <HalCollectionList
             resource={enrichedResource}
             onRefresh={refresh}
+            refreshing={refreshing}
             bulkOperations={[
                 {
                     id: 'delete',

--- a/web.mantine/src/features/sessions/hooks/use_sessions.ts
+++ b/web.mantine/src/features/sessions/hooks/use_sessions.ts
@@ -39,6 +39,7 @@ export function useSessions() {
     // State
     const [data, setData] = useState<HalObject | null>(null);
     const [loading, setLoading] = useState(true);
+    const [refreshing, setRefreshing] = useState(false);
     const [error, setError] = useState<string | null>(null);
     const [sessionsEndpoint, setSessionsEndpoint] = useState<string | null>(null);
 
@@ -96,6 +97,7 @@ export function useSessions() {
             if (!sessionsEndpoint) return;
 
             setLoading(true);
+            setRefreshing(data !== null);
             setError(null);
 
             try {
@@ -109,9 +111,10 @@ export function useSessions() {
                 setData(null);
             } finally {
                 setLoading(false);
+                setRefreshing(false);
             }
         },
-        [sessionsEndpoint]
+        [sessionsEndpoint, data]
     );
 
     /**
@@ -152,6 +155,7 @@ export function useSessions() {
         sessions,
         currentSessionId,
         loading,
+        refreshing,
         error,
         refresh,
     };


### PR DESCRIPTION
## Summary
- Adds `refreshing` state to `useApiKeys` and `useSessions` hooks, matching the pattern already implemented in web.shadcn
- Adds `refreshing` prop to `HalCollectionList` component that spins the refresh icon and disables the button during background re-fetches
- Passes `refreshing` through from `ApiKeysList` and `SessionsList` consumer components
- Uses a CSS module (`hal_collection_list.module.css`) for the `@keyframes spin` animation since Mantine does not include Tailwind's `animate-spin` utility

## Test plan
- [ ] Verify build passes: `cd web.mantine && npm run build`
- [ ] Click Refresh on API Keys page — icon should spin while data loads
- [ ] Click Refresh on Sessions page — icon should spin while data loads
- [ ] On initial page load (no prior data), refresh icon should not spin
- [ ] Button should be disabled while refreshing to prevent double-clicks