### PR TITLE
add Help Center feature for web.mantine

### DIFF
--- a/web.mantine/src/features/dashboard/dashboard.tsx
+++ b/web.mantine/src/features/dashboard/dashboard.tsx
@@ -1,18 +1,19 @@
 import { ActionIcon, Alert, AppShell, Box, Button, Group, ScrollArea, Skeleton, Stack, Text, rem } from '@mantine/core';
 import { useDisclosure, useHeadroom } from '@mantine/hooks';
-import { IconAlertCircle, IconApi, IconChevronLeft, IconChevronRight, IconHelp, IconHome, IconMenu2, IconRefresh, IconSearch } from '@tabler/icons-react';
+import { IconAlertCircle, IconChevronLeft, IconChevronRight, IconHelp, IconHome, IconMenu2, IconRefresh, IconSearch } from '@tabler/icons-react';
 import { ThemeToggle } from '../../components/theme_toggle';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { Route, Routes, useLocation, useNavigate } from 'react-router-dom';
 import { LinksGroup } from '../../components/navbar_links_group/navbar_links_group';
 import { UserButton } from '../../components/user_button/user_button';
 import { Breadcrumbs } from '../../components/breadcrumbs';
-import WebConfigurationStore from '../../configuration/web_config_store';
 import { generateRoutesFromNavStructure } from '../../routing/route_generator';
 import { useSitemap } from '../sitemap/hooks/use_sitemap';
 import classes from './dashboard.module.css';
 import { DashboardHome } from './dashboard_home';
 import { GenericResourceView } from '../resource/generic_resource_view';
+import { HelpPage } from '../help/help_page';
+import { HelpTopicDetail } from '../help/help_topic_detail';
 
 export const Dashboard = () => {
     // Fetch navigation from sitemap API
@@ -23,7 +24,6 @@ export const Dashboard = () => {
     const pinned = useHeadroom({ fixedAt: 120 });
     const [mobileOpened, { toggle: toggleMobile }] = useDisclosure();
     const [desktopOpened, { toggle: toggleDesktop }] = useDisclosure(true);
-    const [apiBaseUrl, setApiBaseUrl] = useState<string>('');
 
     // Track if this is the initial page load
     const isInitialLoad = useRef(true);
@@ -34,19 +34,16 @@ export const Dashboard = () => {
         if (isInitialLoad.current) {
             isInitialLoad.current = false;
 
-            // If initial load and not on dashboard, redirect
-            if (location.pathname !== '/dashboard' && location.pathname !== '/') {
+            // If initial load and not on dashboard or help, redirect
+            if (
+                location.pathname !== '/dashboard' &&
+                location.pathname !== '/' &&
+                !location.pathname.startsWith('/help')
+            ) {
                 navigate('/dashboard', { replace: true });
             }
         }
     }, [location.pathname, navigate]);
-
-    // Load API base URL for documentation link
-    useEffect(() => {
-        WebConfigurationStore.getConfig().then((config) => {
-            setApiBaseUrl(config.api.base_url);
-        });
-    }, []);
 
     // Generate dynamic routes from sitemap
     const dynamicRoutes = useMemo(() => {
@@ -103,14 +100,6 @@ export const Dashboard = () => {
                     label="Home"
                     link="/"
                 />
-                {apiBaseUrl && (
-                    <LinksGroup
-                        icon={IconApi}
-                        label="Hypermedia API Documentation"
-                        link={apiBaseUrl}
-                        newTab={true}
-                    />
-                )}
                 {mainNav.map((item) => <LinksGroup {...item} key={item.label} />)}
             </>
         );
@@ -211,23 +200,16 @@ export const Dashboard = () => {
                                 <IconSearch size={20} />
                             </Box>
 
-                            {/* Help Icon (disabled) */}
-                            <Box
-                                component="span"
-                                style={{
-                                    width: rem(34),
-                                    height: rem(34),
-                                    display: 'flex',
-                                    alignItems: 'center',
-                                    justifyContent: 'center',
-                                    opacity: 0.4,
-                                    cursor: 'not-allowed',
-                                }}
+                            {/* Help Button */}
+                            <ActionIcon
+                                variant="subtle"
+                                size="lg"
+                                onClick={() => navigate('/help')}
                                 aria-label="Help"
-                                title="Help (coming soon)"
+                                title="Help Center"
                             >
                                 <IconHelp size={20} />
-                            </Box>
+                            </ActionIcon>
 
                             {/* Theme Toggle */}
                             <ThemeToggle />
@@ -250,6 +232,10 @@ export const Dashboard = () => {
 
                             {/* Dashboard home route */}
                             <Route path="dashboard" element={<DashboardHome />} />
+
+                            {/* Help Center routes */}
+                            <Route path="help" element={<HelpPage />} />
+                            <Route path="help/:topicId" element={<HelpTopicDetail />} />
 
                             {/* Dynamic routes from sitemap */}
                             {dynamicRoutes.map((route, index) => (

--- a/web.mantine/src/features/help/help_page.tsx
+++ b/web.mantine/src/features/help/help_page.tsx
@@ -1,0 +1,142 @@
+/**
+ * Help Center Page
+ *
+ * Main landing page for the Help Center feature. Displays a responsive
+ * card grid of help topics and a Tools & Resources section with quick
+ * links to API documentation and API key management.
+ */
+
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Button, Group, Paper, SimpleGrid, Stack, Text, ThemeIcon, Title, rem } from '@mantine/core';
+import { IconArrowRight, IconCode, IconHelpCircle, IconKey } from '@tabler/icons-react';
+import WebConfigurationStore from '@/configuration/web_config_store';
+import { helpTopics } from './help_topic_registry';
+import { useSitemap } from '../sitemap/hooks/use_sitemap';
+
+export const HelpPage = () => {
+    const navigate = useNavigate();
+    const [apiBaseUrl, setApiBaseUrl] = useState<string>('');
+    const { links, templates } = useSitemap();
+
+    useEffect(() => {
+        WebConfigurationStore.getConfig().then((config) => {
+            setApiBaseUrl(config.api.base_url);
+        });
+    }, []);
+
+    // Resolve API keys href from sitemap
+    const apiKeysHref = (() => {
+        if (links && links['api-keys']) return links['api-keys'].href;
+        if (templates && templates['api-keys']) return templates['api-keys'].target;
+        return null;
+    })();
+
+    return (
+        <Stack gap="xl">
+            {/* Page Header */}
+            <Stack gap="xs">
+                <Group gap="md">
+                    <ThemeIcon size="xl" radius="md" variant="light">
+                        <IconHelpCircle size={24} />
+                    </ThemeIcon>
+                    <Title order={1}>Help Center</Title>
+                </Group>
+                <Text c="dimmed">
+                    Find guides, references, and answers to common questions.
+                </Text>
+            </Stack>
+
+            {/* Topic Cards Grid */}
+            <SimpleGrid cols={{ base: 1, sm: 2, lg: 3 }} spacing="md">
+                {helpTopics.map((topic) => {
+                    const TopicIcon = topic.icon;
+                    return (
+                        <Paper
+                            key={topic.id}
+                            shadow="sm"
+                            p="lg"
+                            radius="md"
+                            withBorder
+                            style={{ cursor: 'pointer' }}
+                            onClick={() => navigate(`/help/${topic.id}`)}
+                        >
+                            <Stack gap="md">
+                                <Group gap="md">
+                                    <ThemeIcon size="lg" radius="md" variant="light">
+                                        <TopicIcon size={20} />
+                                    </ThemeIcon>
+                                    <Text fw={600} size="lg">
+                                        {topic.title}
+                                    </Text>
+                                </Group>
+                                <Text size="sm" c="dimmed">
+                                    {topic.description}
+                                </Text>
+                            </Stack>
+                        </Paper>
+                    );
+                })}
+            </SimpleGrid>
+
+            {/* Tools & Resources */}
+            <Stack gap="md">
+                <Title order={2} size={rem(24)}>
+                    Tools & Resources
+                </Title>
+                <SimpleGrid cols={{ base: 1, md: 2 }} spacing="md">
+                    {apiBaseUrl && (
+                        <Paper shadow="sm" p="lg" radius="md" withBorder>
+                            <Stack gap="md">
+                                <Group gap="md">
+                                    <ThemeIcon size="lg" radius="md" variant="light">
+                                        <IconCode size={20} />
+                                    </ThemeIcon>
+                                    <Text fw={600} size="lg">
+                                        API Documentation
+                                    </Text>
+                                </Group>
+                                <Text size="sm" c="dimmed">
+                                    Explore the hypermedia API, endpoints, and response formats.
+                                </Text>
+                                <Button
+                                    fullWidth
+                                    variant="outline"
+                                    rightSection={<IconArrowRight size={16} />}
+                                    onClick={() => window.open(apiBaseUrl, '_blank', 'noopener,noreferrer')}
+                                >
+                                    Open API Documentation
+                                </Button>
+                            </Stack>
+                        </Paper>
+                    )}
+
+                    <Paper shadow="sm" p="lg" radius="md" withBorder>
+                        <Stack gap="md">
+                            <Group gap="md">
+                                <ThemeIcon size="lg" radius="md" variant="light">
+                                    <IconKey size={20} />
+                                </ThemeIcon>
+                                <Text fw={600} size="lg">
+                                    API Keys
+                                </Text>
+                            </Group>
+                            <Text size="sm" c="dimmed">
+                                Create and manage API keys for programmatic access to your resources.
+                            </Text>
+                            <Button
+                                fullWidth
+                                variant="outline"
+                                rightSection={<IconArrowRight size={16} />}
+                                onClick={() => apiKeysHref && navigate(apiKeysHref)}
+                                disabled={!apiKeysHref}
+                            >
+                                Manage API Keys
+                            </Button>
+                        </Stack>
+                    </Paper>
+                </SimpleGrid>
+            </Stack>
+        </Stack>
+    );
+};

--- a/web.mantine/src/features/help/help_topic_detail.tsx
+++ b/web.mantine/src/features/help/help_topic_detail.tsx
@@ -1,0 +1,53 @@
+/**
+ * Help Topic Detail
+ *
+ * Wrapper component that resolves the topic from the URL parameter
+ * and renders the corresponding content component.
+ */
+
+import { useParams, useNavigate } from 'react-router-dom';
+import { Button, Stack, Text, Title } from '@mantine/core';
+import { IconArrowLeft } from '@tabler/icons-react';
+import { getHelpTopicById } from './help_topic_registry';
+
+export const HelpTopicDetail = () => {
+    const { topicId } = useParams<{ topicId: string }>();
+    const navigate = useNavigate();
+
+    const topic = topicId ? getHelpTopicById(topicId) : undefined;
+
+    if (!topic) {
+        return (
+            <Stack gap="xl">
+                <Button
+                    variant="subtle"
+                    leftSection={<IconArrowLeft size={16} />}
+                    onClick={() => navigate('/help')}
+                >
+                    Back to Help Center
+                </Button>
+                <Stack align="center" py="xl">
+                    <Title order={2}>Topic Not Found</Title>
+                    <Text c="dimmed">
+                        The help topic you are looking for does not exist.
+                    </Text>
+                </Stack>
+            </Stack>
+        );
+    }
+
+    const TopicContent = topic.component;
+
+    return (
+        <Stack gap="xl">
+            <Button
+                variant="subtle"
+                leftSection={<IconArrowLeft size={16} />}
+                onClick={() => navigate('/help')}
+            >
+                Back to Help Center
+            </Button>
+            <TopicContent />
+        </Stack>
+    );
+};

--- a/web.mantine/src/features/help/help_topic_registry.tsx
+++ b/web.mantine/src/features/help/help_topic_registry.tsx
@@ -1,0 +1,85 @@
+/**
+ * Help Topic Registry
+ *
+ * Defines all available help topics with metadata for the Help Center.
+ * Each topic has a URL slug, display metadata, icon, and content component.
+ */
+
+import type { ComponentType } from 'react';
+import type { Icon } from '@tabler/icons-react';
+import { IconBook, IconKey, IconShield, IconShieldCheck, IconHelpCircle } from '@tabler/icons-react';
+import { GettingStartedContent } from './topics/getting_started';
+import { ApiKeysContent } from './topics/api_keys';
+import { SessionsSecurityContent } from './topics/sessions_security';
+import { AdminContent } from './topics/admin';
+import { FaqContent } from './topics/faq';
+
+/**
+ * Help topic definition
+ */
+export interface HelpTopic {
+    /** URL slug (e.g., "getting-started") */
+    id: string;
+    /** Card title */
+    title: string;
+    /** Card description */
+    description: string;
+    /** Card icon */
+    icon: Icon;
+    /** Detail page content component */
+    component: ComponentType;
+}
+
+/**
+ * Registry of all help topics
+ *
+ * Add new topics here as the application evolves. Each topic appears
+ * as a card on the Help Center page and has a dedicated detail page.
+ */
+export const helpTopics: HelpTopic[] = [
+    {
+        id: 'getting-started',
+        title: 'Getting Started',
+        description: 'Learn the basics of Serverless Launchpad and get up and running quickly.',
+        icon: IconBook,
+        component: GettingStartedContent,
+    },
+    {
+        id: 'api-keys',
+        title: 'API Keys',
+        description: 'Understand how to create, manage, and use API keys for programmatic access.',
+        icon: IconKey,
+        component: ApiKeysContent,
+    },
+    {
+        id: 'sessions-security',
+        title: 'Sessions & Security',
+        description: 'Learn about session management, security best practices, and account protection.',
+        icon: IconShield,
+        component: SessionsSecurityContent,
+    },
+    {
+        id: 'admin',
+        title: 'Admin',
+        description: 'Administration tools, user management, and system configuration.',
+        icon: IconShieldCheck,
+        component: AdminContent,
+    },
+    {
+        id: 'faq',
+        title: 'FAQ',
+        description: 'Frequently asked questions and common troubleshooting tips.',
+        icon: IconHelpCircle,
+        component: FaqContent,
+    },
+];
+
+/**
+ * Find a help topic by its URL slug
+ *
+ * @param id - Topic URL slug
+ * @returns The matching HelpTopic, or undefined if not found
+ */
+export function getHelpTopicById(id: string): HelpTopic | undefined {
+    return helpTopics.find((topic) => topic.id === id);
+}

--- a/web.mantine/src/features/help/topics/admin.tsx
+++ b/web.mantine/src/features/help/topics/admin.tsx
@@ -1,0 +1,18 @@
+/**
+ * Admin Help Topic Content
+ */
+
+import { Paper, Text, Title } from '@mantine/core';
+
+export const AdminContent = () => {
+    return (
+        <Paper shadow="sm" p="lg" radius="md" withBorder>
+            <Title order={3} mb="md">
+                Admin
+            </Title>
+            <Text c="dimmed">
+                This section is a placeholder. Content will be added as the application evolves.
+            </Text>
+        </Paper>
+    );
+};

--- a/web.mantine/src/features/help/topics/api_keys.tsx
+++ b/web.mantine/src/features/help/topics/api_keys.tsx
@@ -1,0 +1,18 @@
+/**
+ * API Keys Help Topic Content
+ */
+
+import { Paper, Text, Title } from '@mantine/core';
+
+export const ApiKeysContent = () => {
+    return (
+        <Paper shadow="sm" p="lg" radius="md" withBorder>
+            <Title order={3} mb="md">
+                API Keys
+            </Title>
+            <Text c="dimmed">
+                This section is a placeholder. Content will be added as the application evolves.
+            </Text>
+        </Paper>
+    );
+};

--- a/web.mantine/src/features/help/topics/faq.tsx
+++ b/web.mantine/src/features/help/topics/faq.tsx
@@ -1,0 +1,18 @@
+/**
+ * FAQ Help Topic Content
+ */
+
+import { Paper, Text, Title } from '@mantine/core';
+
+export const FaqContent = () => {
+    return (
+        <Paper shadow="sm" p="lg" radius="md" withBorder>
+            <Title order={3} mb="md">
+                FAQ
+            </Title>
+            <Text c="dimmed">
+                This section is a placeholder. Content will be added as the application evolves.
+            </Text>
+        </Paper>
+    );
+};

--- a/web.mantine/src/features/help/topics/getting_started.tsx
+++ b/web.mantine/src/features/help/topics/getting_started.tsx
@@ -1,0 +1,18 @@
+/**
+ * Getting Started Help Topic Content
+ */
+
+import { Paper, Text, Title } from '@mantine/core';
+
+export const GettingStartedContent = () => {
+    return (
+        <Paper shadow="sm" p="lg" radius="md" withBorder>
+            <Title order={3} mb="md">
+                Getting Started
+            </Title>
+            <Text c="dimmed">
+                This section is a placeholder. Content will be added as the application evolves.
+            </Text>
+        </Paper>
+    );
+};

--- a/web.mantine/src/features/help/topics/sessions_security.tsx
+++ b/web.mantine/src/features/help/topics/sessions_security.tsx
@@ -1,0 +1,18 @@
+/**
+ * Sessions & Security Help Topic Content
+ */
+
+import { Paper, Text, Title } from '@mantine/core';
+
+export const SessionsSecurityContent = () => {
+    return (
+        <Paper shadow="sm" p="lg" radius="md" withBorder>
+            <Title order={3} mb="md">
+                Sessions & Security
+            </Title>
+            <Text c="dimmed">
+                This section is a placeholder. Content will be added as the application evolves.
+            </Text>
+        </Paper>
+    );
+};


### PR DESCRIPTION
## Summary
- Adds Help Center feature to `web.mantine`, adapted from the `web.shadcn` reference implementation using Mantine components (Paper, SimpleGrid, ThemeIcon, Title, Text, Button, Stack, Group) and Tabler Icons
- Help page displays a responsive card grid (1/2/3 columns) of 5 placeholder help topics plus a Tools & Resources section with API Documentation (opens in new tab) and API Keys links
- Header Help button is now active and navigates to `/help`; API Documentation link removed from sidebar navigation (relocated to Help Center)
- Registers `/help` and `/help/:topicId` routes with initial-load bypass so help pages are directly accessible

## Test plan
- [ ] Verify `cd web.mantine && npm run build` passes
- [ ] Navigate to Help Center via header Help icon button
- [ ] Confirm 5 topic cards render in a responsive grid (1 col mobile, 2 col sm, 3 col lg)
- [ ] Click a topic card and verify detail page loads with back navigation
- [ ] Click "Open API Documentation" and verify it opens in a new tab
- [ ] Click "Manage API Keys" and verify it navigates to the API keys page
- [ ] Confirm API Documentation is no longer in the sidebar
- [ ] Verify direct URL navigation to `/help` is not redirected to dashboard

Generated with [Claude Code](https://claude.com/claude-code)