### PR TITLE
Add refresh button animation to web.daisyui

### DIFF
--- a/web.daisyui/src/components/hal_collection/hal_collection_list.tsx
+++ b/web.daisyui/src/components/hal_collection/hal_collection_list.tsx
@@ -33,6 +33,8 @@ export interface HalCollectionListProps {
     emptyIcon?: React.ReactNode;
     showCreateButton?: boolean;
     showRefreshButton?: boolean;
+    /** Whether a background refresh is in progress (spins the refresh icon) */
+    refreshing?: boolean;
     selectableFilter?: (item: HalObject) => boolean;
     /** Page title to display in the header row */
     title?: string;
@@ -80,6 +82,7 @@ export function HalCollectionList({
     emptyIcon,
     showCreateButton = true,
     showRefreshButton = true,
+    refreshing = false,
     selectableFilter,
     title,
     bulkOperations = [],
@@ -169,8 +172,8 @@ export function HalCollectionList({
                         </button>
                     )}
                     {showRefreshButton && (
-                        <button className="btn btn-sm border border-base-300 bg-base-100 hover:bg-base-200" onClick={handleRefresh}>
-                            <RefreshCw className="w-4 h-4 mr-2" />
+                        <button className="btn btn-sm border border-base-300 bg-base-100 hover:bg-base-200" onClick={handleRefresh} disabled={refreshing}>
+                            <RefreshCw className={`w-4 h-4 mr-2 ${refreshing ? 'animate-spin' : ''}`} />
                             Refresh
                         </button>
                     )}
@@ -237,8 +240,8 @@ export function HalCollectionList({
                         </button>
                     )}
                     {showRefreshButton && (
-                        <button className="btn btn-sm border border-base-300 bg-base-100 hover:bg-base-200" onClick={handleRefresh}>
-                            <RefreshCw className="w-4 h-4 mr-2" />
+                        <button className="btn btn-sm border border-base-300 bg-base-100 hover:bg-base-200" onClick={handleRefresh} disabled={refreshing}>
+                            <RefreshCw className={`w-4 h-4 mr-2 ${refreshing ? 'animate-spin' : ''}`} />
                             Refresh
                         </button>
                     )}

--- a/web.daisyui/src/features/api_keys/components/api_keys_list.tsx
+++ b/web.daisyui/src/features/api_keys/components/api_keys_list.tsx
@@ -32,7 +32,7 @@ import { HalCollectionList } from '../../../components/hal_collection';
  * ```
  */
 export function ApiKeysList() {
-    const { data, refresh } = useApiKeys();
+    const { data, refreshing, refresh } = useApiKeys();
 
     const [createModalOpened, { open: openCreateModal, close: closeCreateModal }] =
         useDisclosure(false);
@@ -76,6 +76,7 @@ export function ApiKeysList() {
             <HalCollectionList
                 resource={data}
                 onRefresh={refresh}
+                refreshing={refreshing}
                 onCreate={openCreateModal}
                 bulkOperations={[
                     {

--- a/web.daisyui/src/features/api_keys/hooks/use_api_keys.ts
+++ b/web.daisyui/src/features/api_keys/hooks/use_api_keys.ts
@@ -39,6 +39,7 @@ export function useApiKeys() {
     // State
     const [data, setData] = useState<HalObject | null>(null);
     const [loading, setLoading] = useState(true);
+    const [refreshing, setRefreshing] = useState(false);
     const [error, setError] = useState<string | null>(null);
     const [apiKeysEndpoint, setApiKeysEndpoint] = useState<string | null>(null);
 
@@ -95,6 +96,7 @@ export function useApiKeys() {
         if (!apiKeysEndpoint) return;
 
         setLoading(true);
+        setRefreshing(data !== null);
         setError(null);
 
         try {
@@ -108,8 +110,9 @@ export function useApiKeys() {
             setData(null);
         } finally {
             setLoading(false);
+            setRefreshing(false);
         }
-    }, [apiKeysEndpoint]);
+    }, [apiKeysEndpoint, data]);
 
     /**
      * Refresh API keys list
@@ -133,6 +136,7 @@ export function useApiKeys() {
     return {
         data,
         loading,
+        refreshing,
         error,
         refresh,
     };

--- a/web.daisyui/src/features/sessions/components/sessions_list.tsx
+++ b/web.daisyui/src/features/sessions/components/sessions_list.tsx
@@ -31,7 +31,7 @@ import { parseUserAgent } from '../utils/parse_user_agent';
  * ```
  */
 export function SessionsList() {
-    const { data, sessions, refresh } = useSessions();
+    const { data, sessions, refreshing, refresh } = useSessions();
 
     // Create enriched resource with isCurrent property on sessions
     const enrichedResource = useMemo(() => {
@@ -120,6 +120,7 @@ export function SessionsList() {
         <HalCollectionList
             resource={enrichedResource}
             onRefresh={refresh}
+            refreshing={refreshing}
             bulkOperations={[
                 {
                     id: 'delete',

--- a/web.daisyui/src/features/sessions/hooks/use_sessions.ts
+++ b/web.daisyui/src/features/sessions/hooks/use_sessions.ts
@@ -46,6 +46,7 @@ export function useSessions() {
     // State
     const [data, setData] = useState<HalObject | null>(null);
     const [loading, setLoading] = useState(true);
+    const [refreshing, setRefreshing] = useState(false);
     const [error, setError] = useState<string | null>(null);
     const [sessionsEndpoint, setSessionsEndpoint] = useState<string | null>(null);
 
@@ -102,6 +103,7 @@ export function useSessions() {
         if (!sessionsEndpoint) return;
 
         setLoading(true);
+        setRefreshing(data !== null);
         setError(null);
 
         try {
@@ -115,8 +117,9 @@ export function useSessions() {
             setData(null);
         } finally {
             setLoading(false);
+            setRefreshing(false);
         }
-    }, [sessionsEndpoint]);
+    }, [sessionsEndpoint, data]);
 
     /**
      * Refresh sessions list
@@ -156,6 +159,7 @@ export function useSessions() {
         sessions,
         currentSessionId,
         loading,
+        refreshing,
         error,
         refresh,
     };


### PR DESCRIPTION
## Summary
- Adds a `refreshing` prop to `HalCollectionList` in web.daisyui that spins the `RefreshCw` icon via Tailwind's `animate-spin` class and disables the button during background re-fetches
- Adds `refreshing` state to `useApiKeys` and `useSessions` hooks, set to `true` only when data already exists and a re-fetch is in progress (not on initial load)
- Passes `refreshing` from consumer components (`ApiKeysList`, `SessionsList`) through to `HalCollectionList`
- Mirrors the pattern already established in web.shadcn

## Test plan
- [ ] Navigate to API Keys page, click Refresh — icon should spin and button should be disabled until data returns
- [ ] Navigate to Sessions page, click Refresh — same spinning/disabled behavior
- [ ] On initial page load, the refresh button should not spin (refreshing is false during first fetch)
- [ ] Verify `npm run build` passes in web.daisyui

🤖 Generated with [Claude Code](https://claude.com/claude-code)