### PR TITLE
add Help Center feature for web.daisyui

### DIFF
--- a/web.daisyui/src/features/dashboard/dashboard.tsx
+++ b/web.daisyui/src/features/dashboard/dashboard.tsx
@@ -1,17 +1,18 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { Route, Routes, useLocation, useNavigate } from 'react-router-dom';
-import { Home, Code2, ChevronRight, Menu, AlertCircle, RefreshCw, Search, HelpCircle } from 'lucide-react';
+import { Home, ChevronRight, Menu, AlertCircle, RefreshCw, Search, HelpCircle } from 'lucide-react';
 import { LinksGroup } from '@/components/navbar_links_group/navbar_links_group';
 import { UserButton } from '@/components/user_button/user_button';
 import { Breadcrumbs } from '@/components/breadcrumbs';
 import { cn } from '@/lib/utils';
 import { useDisclosure } from '@/hooks/use_disclosure';
 import { useHeadroom } from '@/hooks/use_headroom';
-import WebConfigurationStore from '@/configuration/web_config_store';
 import { generateRoutesFromNavStructure } from '@/routing/route_generator';
 import { useSitemap } from '../sitemap/hooks/use_sitemap';
 import { DashboardHome } from './dashboard_home';
 import { SettingsPage } from '../settings/settings_page';
+import { HelpPage } from '../help/help_page';
+import { HelpTopicDetail } from '../help/help_topic_detail';
 import { GenericResourceView } from '../resource/generic_resource_view';
 
 /**
@@ -33,7 +34,6 @@ export const Dashboard = () => {
     const pinned = useHeadroom({ fixedAt: 120 });
     const [mobileOpened, { toggle: toggleMobile }] = useDisclosure(false);
     const [desktopOpened, { toggle: toggleDesktop }] = useDisclosure(true);
-    const [apiBaseUrl, setApiBaseUrl] = useState<string>('');
 
     // Track if this is the initial page load
     const isInitialLoad = useRef(true);
@@ -44,19 +44,16 @@ export const Dashboard = () => {
         if (isInitialLoad.current) {
             isInitialLoad.current = false;
 
-            // If initial load and not on dashboard, redirect
-            if (location.pathname !== '/dashboard' && location.pathname !== '/') {
+            // If initial load and not on dashboard or help, redirect
+            if (
+                location.pathname !== '/dashboard' &&
+                location.pathname !== '/' &&
+                !location.pathname.startsWith('/help')
+            ) {
                 navigate('/dashboard', { replace: true });
             }
         }
     }, [location.pathname, navigate]);
-
-    // Load API base URL for documentation link
-    useEffect(() => {
-        WebConfigurationStore.getConfig().then((config) => {
-            setApiBaseUrl(config.api.base_url);
-        });
-    }, []);
 
     // Generate dynamic routes from sitemap
     const dynamicRoutes = useMemo(() => {
@@ -103,7 +100,6 @@ export const Dashboard = () => {
         return (
             <>
                 <LinksGroup icon={Home} label="Home" link="/" />
-                {apiBaseUrl && <LinksGroup icon={Code2} label="Hypermedia API Documentation" link={apiBaseUrl} newTab={true} />}
                 {mainNav.map((item) => (
                     <LinksGroup {...item} key={item.label} />
                 ))}
@@ -178,14 +174,15 @@ export const Dashboard = () => {
                             <Search className="h-5 w-5" />
                         </span>
 
-                        {/* Help Icon (disabled) */}
-                        <span
-                            className="w-12 h-12 flex items-center justify-center opacity-40 cursor-not-allowed"
+                        {/* Help Button */}
+                        <button
+                            className="btn btn-square btn-ghost"
+                            onClick={() => navigate('/help')}
                             aria-label="Help"
-                            title="Help (coming soon)"
+                            title="Help Center"
                         >
                             <HelpCircle className="h-5 w-5" />
-                        </span>
+                        </button>
                     </div>
                 </div>
 
@@ -207,6 +204,10 @@ export const Dashboard = () => {
 
                             {/* Client-side routes */}
                             <Route path="settings" element={<SettingsPage />} />
+
+                            {/* Help Center routes */}
+                            <Route path="help" element={<HelpPage />} />
+                            <Route path="help/:topicId" element={<HelpTopicDetail />} />
 
                             {/* Dynamic routes from sitemap */}
                             {dynamicRoutes.map((route, index) => (

--- a/web.daisyui/src/features/help/help_page.tsx
+++ b/web.daisyui/src/features/help/help_page.tsx
@@ -1,0 +1,129 @@
+/**
+ * Help Center Page
+ *
+ * Main landing page for the Help Center feature. Displays a responsive
+ * card grid of help topics and a Tools & Resources section with quick
+ * links to API documentation and API key management.
+ */
+
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { ArrowRight, Code2, Key, LifeBuoy } from 'lucide-react';
+import WebConfigurationStore from '@/configuration/web_config_store';
+import { helpTopics } from './help_topic_registry';
+import { useSitemap } from '../sitemap/hooks/use_sitemap';
+
+export const HelpPage = () => {
+    const navigate = useNavigate();
+    const [apiBaseUrl, setApiBaseUrl] = useState<string>('');
+    const { links, templates } = useSitemap();
+
+    useEffect(() => {
+        WebConfigurationStore.getConfig().then((config) => {
+            setApiBaseUrl(config.api.base_url);
+        });
+    }, []);
+
+    // Resolve API keys href from sitemap
+    const apiKeysHref = (() => {
+        if (links && links['api-keys']) return links['api-keys'].href;
+        if (templates && templates['api-keys']) return templates['api-keys'].target;
+        return null;
+    })();
+
+    return (
+        <div className="space-y-8">
+            {/* Page Header */}
+            <div className="space-y-2">
+                <div className="flex items-center gap-3">
+                    <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
+                        <LifeBuoy className="h-5 w-5 text-primary" />
+                    </div>
+                    <h1 className="text-3xl font-bold tracking-tight">Help Center</h1>
+                </div>
+                <p className="text-base-content/70">
+                    Find guides, references, and answers to common questions.
+                </p>
+            </div>
+
+            {/* Topic Cards Grid */}
+            <div className="grid gap-4 grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
+                {helpTopics.map((topic) => {
+                    const Icon = topic.icon;
+                    return (
+                        <div
+                            key={topic.id}
+                            className="card bg-base-100 shadow-xl hover:shadow-2xl transition-shadow cursor-pointer"
+                            onClick={() => navigate(`/help/${topic.id}`)}
+                        >
+                            <div className="card-body">
+                                <div className="flex items-center gap-3">
+                                    <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
+                                        <Icon className="h-5 w-5 text-primary" />
+                                    </div>
+                                    <h2 className="card-title text-lg">{topic.title}</h2>
+                                </div>
+                                <p className="text-base-content/70 mt-2">{topic.description}</p>
+                            </div>
+                        </div>
+                    );
+                })}
+            </div>
+
+            {/* Tools & Resources */}
+            <div>
+                <h2 className="text-2xl font-semibold tracking-tight mb-4">Tools & Resources</h2>
+                <div className="grid gap-4 md:grid-cols-2">
+                    {apiBaseUrl && (
+                        <div className="card bg-base-100 shadow-xl hover:shadow-2xl transition-shadow">
+                            <div className="card-body">
+                                <div className="flex items-center gap-3">
+                                    <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
+                                        <Code2 className="h-5 w-5 text-primary" />
+                                    </div>
+                                    <h3 className="card-title text-lg">API Documentation</h3>
+                                </div>
+                                <p className="text-base-content/70 mt-2">
+                                    Explore the hypermedia API, endpoints, and response formats.
+                                </p>
+                                <div className="card-actions mt-3">
+                                    <button
+                                        className="btn btn-outline w-full"
+                                        onClick={() => window.open(apiBaseUrl, '_blank', 'noopener,noreferrer')}
+                                    >
+                                        Open API Documentation
+                                        <ArrowRight className="ml-2 h-4 w-4" />
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+                    )}
+
+                    <div className="card bg-base-100 shadow-xl hover:shadow-2xl transition-shadow">
+                        <div className="card-body">
+                            <div className="flex items-center gap-3">
+                                <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
+                                    <Key className="h-5 w-5 text-primary" />
+                                </div>
+                                <h3 className="card-title text-lg">API Keys</h3>
+                            </div>
+                            <p className="text-base-content/70 mt-2">
+                                Create and manage API keys for programmatic access to your resources.
+                            </p>
+                            <div className="card-actions mt-3">
+                                <button
+                                    className="btn btn-outline w-full"
+                                    onClick={() => apiKeysHref && navigate(apiKeysHref)}
+                                    disabled={!apiKeysHref}
+                                >
+                                    Manage API Keys
+                                    <ArrowRight className="ml-2 h-4 w-4" />
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+};

--- a/web.daisyui/src/features/help/help_topic_detail.tsx
+++ b/web.daisyui/src/features/help/help_topic_detail.tsx
@@ -1,0 +1,46 @@
+/**
+ * Help Topic Detail
+ *
+ * Wrapper component that resolves the topic from the URL parameter
+ * and renders the corresponding content component.
+ */
+
+import { useParams, useNavigate } from 'react-router-dom';
+import { ArrowLeft } from 'lucide-react';
+import { getHelpTopicById } from './help_topic_registry';
+
+export const HelpTopicDetail = () => {
+    const { topicId } = useParams<{ topicId: string }>();
+    const navigate = useNavigate();
+
+    const topic = topicId ? getHelpTopicById(topicId) : undefined;
+
+    if (!topic) {
+        return (
+            <div className="space-y-6">
+                <button onClick={() => navigate('/help')} className="btn btn-ghost gap-2">
+                    <ArrowLeft className="h-4 w-4" />
+                    Back to Help Center
+                </button>
+                <div className="text-center py-12">
+                    <h2 className="text-2xl font-semibold tracking-tight">Topic Not Found</h2>
+                    <p className="text-base-content/70 mt-2">
+                        The help topic you are looking for does not exist.
+                    </p>
+                </div>
+            </div>
+        );
+    }
+
+    const TopicContent = topic.component;
+
+    return (
+        <div className="space-y-6">
+            <button onClick={() => navigate('/help')} className="btn btn-ghost gap-2">
+                <ArrowLeft className="h-4 w-4" />
+                Back to Help Center
+            </button>
+            <TopicContent />
+        </div>
+    );
+};

--- a/web.daisyui/src/features/help/help_topic_registry.tsx
+++ b/web.daisyui/src/features/help/help_topic_registry.tsx
@@ -1,0 +1,85 @@
+/**
+ * Help Topic Registry
+ *
+ * Defines all available help topics with metadata for the Help Center.
+ * Each topic has a URL slug, display metadata, icon, and content component.
+ */
+
+import type { ComponentType } from 'react';
+import type { LucideIcon } from 'lucide-react';
+import { BookOpen, Key, Shield, ShieldCheck, HelpCircle } from 'lucide-react';
+import { GettingStartedContent } from './topics/getting_started';
+import { ApiKeysContent } from './topics/api_keys';
+import { SessionsSecurityContent } from './topics/sessions_security';
+import { AdminContent } from './topics/admin';
+import { FaqContent } from './topics/faq';
+
+/**
+ * Help topic definition
+ */
+export interface HelpTopic {
+    /** URL slug (e.g., "getting-started") */
+    id: string;
+    /** Card title */
+    title: string;
+    /** Card description */
+    description: string;
+    /** Card icon */
+    icon: LucideIcon;
+    /** Detail page content component */
+    component: ComponentType;
+}
+
+/**
+ * Registry of all help topics
+ *
+ * Add new topics here as the application evolves. Each topic appears
+ * as a card on the Help Center page and has a dedicated detail page.
+ */
+export const helpTopics: HelpTopic[] = [
+    {
+        id: 'getting-started',
+        title: 'Getting Started',
+        description: 'Learn the basics of Serverless Launchpad and get up and running quickly.',
+        icon: BookOpen,
+        component: GettingStartedContent,
+    },
+    {
+        id: 'api-keys',
+        title: 'API Keys',
+        description: 'Understand how to create, manage, and use API keys for programmatic access.',
+        icon: Key,
+        component: ApiKeysContent,
+    },
+    {
+        id: 'sessions-security',
+        title: 'Sessions & Security',
+        description: 'Learn about session management, security best practices, and account protection.',
+        icon: Shield,
+        component: SessionsSecurityContent,
+    },
+    {
+        id: 'admin',
+        title: 'Admin',
+        description: 'Administration tools, user management, and system configuration.',
+        icon: ShieldCheck,
+        component: AdminContent,
+    },
+    {
+        id: 'faq',
+        title: 'FAQ',
+        description: 'Frequently asked questions and common troubleshooting tips.',
+        icon: HelpCircle,
+        component: FaqContent,
+    },
+];
+
+/**
+ * Find a help topic by its URL slug
+ *
+ * @param id - Topic URL slug
+ * @returns The matching HelpTopic, or undefined if not found
+ */
+export function getHelpTopicById(id: string): HelpTopic | undefined {
+    return helpTopics.find((topic) => topic.id === id);
+}

--- a/web.daisyui/src/features/help/topics/admin.tsx
+++ b/web.daisyui/src/features/help/topics/admin.tsx
@@ -1,0 +1,16 @@
+/**
+ * Admin Help Topic Content
+ */
+
+export const AdminContent = () => {
+    return (
+        <div className="card bg-base-100 shadow-xl">
+            <div className="card-body">
+                <h2 className="card-title">Admin</h2>
+                <p className="text-base-content/70">
+                    This section is a placeholder. Content will be added as the application evolves.
+                </p>
+            </div>
+        </div>
+    );
+};

--- a/web.daisyui/src/features/help/topics/api_keys.tsx
+++ b/web.daisyui/src/features/help/topics/api_keys.tsx
@@ -1,0 +1,16 @@
+/**
+ * API Keys Help Topic Content
+ */
+
+export const ApiKeysContent = () => {
+    return (
+        <div className="card bg-base-100 shadow-xl">
+            <div className="card-body">
+                <h2 className="card-title">API Keys</h2>
+                <p className="text-base-content/70">
+                    This section is a placeholder. Content will be added as the application evolves.
+                </p>
+            </div>
+        </div>
+    );
+};

--- a/web.daisyui/src/features/help/topics/faq.tsx
+++ b/web.daisyui/src/features/help/topics/faq.tsx
@@ -1,0 +1,16 @@
+/**
+ * FAQ Help Topic Content
+ */
+
+export const FaqContent = () => {
+    return (
+        <div className="card bg-base-100 shadow-xl">
+            <div className="card-body">
+                <h2 className="card-title">FAQ</h2>
+                <p className="text-base-content/70">
+                    This section is a placeholder. Content will be added as the application evolves.
+                </p>
+            </div>
+        </div>
+    );
+};

--- a/web.daisyui/src/features/help/topics/getting_started.tsx
+++ b/web.daisyui/src/features/help/topics/getting_started.tsx
@@ -1,0 +1,16 @@
+/**
+ * Getting Started Help Topic Content
+ */
+
+export const GettingStartedContent = () => {
+    return (
+        <div className="card bg-base-100 shadow-xl">
+            <div className="card-body">
+                <h2 className="card-title">Getting Started</h2>
+                <p className="text-base-content/70">
+                    This section is a placeholder. Content will be added as the application evolves.
+                </p>
+            </div>
+        </div>
+    );
+};

--- a/web.daisyui/src/features/help/topics/sessions_security.tsx
+++ b/web.daisyui/src/features/help/topics/sessions_security.tsx
@@ -1,0 +1,16 @@
+/**
+ * Sessions & Security Help Topic Content
+ */
+
+export const SessionsSecurityContent = () => {
+    return (
+        <div className="card bg-base-100 shadow-xl">
+            <div className="card-body">
+                <h2 className="card-title">Sessions & Security</h2>
+                <p className="text-base-content/70">
+                    This section is a placeholder. Content will be added as the application evolves.
+                </p>
+            </div>
+        </div>
+    );
+};


### PR DESCRIPTION
## Summary
- Add Help Center feature to `web.daisyui` with help page, topic registry, topic detail, and 5 placeholder topic components (Getting Started, API Keys, Sessions & Security, Admin, FAQ)
- Enable header Help button to navigate to `/help` and register `/help` and `/help/:topicId` routes
- Remove API Documentation link from the sidebar (moved to Help Center Tools & Resources section)

## Test plan
- [ ] Verify `npm run build` passes for `web.daisyui`
- [ ] Navigate to `/help` via header Help button and confirm topic card grid renders
- [ ] Click each topic card and verify detail page renders with back button
- [ ] Confirm Tools & Resources section shows API Documentation (opens new tab) and API Keys links
- [ ] Verify API Documentation is no longer in the sidebar
- [ ] Verify direct navigation to `/help` on page load is not redirected to dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)