### PR TITLE
add Help Center feature for web.svelte with topic registry and detail pages

### DIFF
--- a/web.svelte/src/lib/components/dashboard/app-header.svelte
+++ b/web.svelte/src/lib/components/dashboard/app-header.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { sidebarStore } from '$lib/stores/sidebar_store';
+	import { goto } from '$app/navigation';
 	import { Menu, Search, HelpCircle, ChevronsLeft, ChevronsRight } from 'lucide-svelte';
 	import Breadcrumbs from './breadcrumbs.svelte';
 	import ThemeToggle from './theme-toggle.svelte';
@@ -64,9 +65,9 @@
 		<Button
 			variant="ghost"
 			size="icon"
-			disabled
+			on:click={() => goto('/help')}
 			aria-label="Help"
-			title="Help (coming soon)"
+			title="Help Center"
 		>
 			<HelpCircle class="h-5 w-5" />
 		</Button>

--- a/web.svelte/src/lib/components/dashboard/app-sidebar.svelte
+++ b/web.svelte/src/lib/components/dashboard/app-sidebar.svelte
@@ -6,13 +6,10 @@
 	import { goto } from '$app/navigation';
 	import { signOut } from '$lib/auth';
 	import { authStore } from '$lib/stores/auth_store';
-	import { onMount } from 'svelte';
-	import webConfigStore from '$lib/config/web_config_store';
 	import {
 		Home,
 		Key,
 		Clock,
-		BookOpen,
 		User,
 		LogOut,
 		ChevronRight
@@ -29,18 +26,12 @@
 	};
 	// Track which groups have been manually toggled by the user
 	let manuallyToggled: Record<string, boolean> = {};
-	let apiBaseUrl = '';
 
 	function toggleMenuGroup(label: string) {
 		openMenuGroups[label] = !openMenuGroups[label];
 		manuallyToggled[label] = true;
 		openMenuGroups = { ...openMenuGroups };
 	}
-
-	onMount(async () => {
-		const config = await webConfigStore.getConfig();
-		apiBaseUrl = config.api.base_url;
-	});
 
 	function navigate(path: string, rel?: string) {
 		if (currentPath === path) {
@@ -148,21 +139,6 @@
 					<span>Home</span>
 				</button>
 			</li>
-
-			<!-- Hypermedia API Documentation -->
-			{#if apiBaseUrl}
-				<li>
-					<button
-						on:click={() => window.open(apiBaseUrl, '_blank')}
-						class="w-full flex items-center justify-start gap-3 px-3 py-2 rounded-md hover:bg-accent hover:text-accent-foreground transition-colors text-sm font-medium"
-					>
-						<div class="flex items-center justify-center w-8 h-8 rounded-md bg-primary/10 text-primary">
-							<BookOpen class="h-4 w-4" />
-						</div>
-						<span class="text-left">Hypermedia API Docs</span>
-					</button>
-				</li>
-			{/if}
 
 			<!-- Dynamic Navigation from Sitemap (HATEOAS-driven) -->
 			{#if isLoadingSitemap}

--- a/web.svelte/src/lib/features/help/help_topic_registry.ts
+++ b/web.svelte/src/lib/features/help/help_topic_registry.ts
@@ -1,0 +1,79 @@
+/**
+ * Help Topic Registry
+ *
+ * Defines all available help topics with metadata for the Help Center.
+ * Each topic has a URL slug, display metadata, and icon name for inline rendering.
+ */
+
+import type { ComponentType, SvelteComponent } from 'svelte';
+
+/**
+ * Help topic definition
+ */
+export interface HelpTopic {
+	/** URL slug (e.g., "getting-started") */
+	id: string;
+	/** Card title */
+	title: string;
+	/** Card description */
+	description: string;
+	/** Icon identifier for inline rendering */
+	icon: 'book-open' | 'key' | 'shield' | 'shield-check' | 'help-circle';
+	/** Lazy loader for detail page content component */
+	load: () => Promise<{ default: ComponentType<SvelteComponent> }>;
+}
+
+/**
+ * Registry of all help topics
+ *
+ * Add new topics here as the application evolves. Each topic appears
+ * as a card on the Help Center page and has a dedicated detail page.
+ */
+export const helpTopics: HelpTopic[] = [
+	{
+		id: 'getting-started',
+		title: 'Getting Started',
+		description: 'Learn the basics of Serverless Launchpad and get up and running quickly.',
+		icon: 'book-open',
+		load: () => import('./topics/getting_started.svelte')
+	},
+	{
+		id: 'api-keys',
+		title: 'API Keys',
+		description: 'Understand how to create, manage, and use API keys for programmatic access.',
+		icon: 'key',
+		load: () => import('./topics/api_keys.svelte')
+	},
+	{
+		id: 'sessions-security',
+		title: 'Sessions & Security',
+		description:
+			'Learn about session management, security best practices, and account protection.',
+		icon: 'shield',
+		load: () => import('./topics/sessions_security.svelte')
+	},
+	{
+		id: 'admin',
+		title: 'Admin',
+		description: 'Administration tools, user management, and system configuration.',
+		icon: 'shield-check',
+		load: () => import('./topics/admin.svelte')
+	},
+	{
+		id: 'faq',
+		title: 'FAQ',
+		description: 'Frequently asked questions and common troubleshooting tips.',
+		icon: 'help-circle',
+		load: () => import('./topics/faq.svelte')
+	}
+];
+
+/**
+ * Find a help topic by its URL slug
+ *
+ * @param id - Topic URL slug
+ * @returns The matching HelpTopic, or undefined if not found
+ */
+export function getHelpTopicById(id: string): HelpTopic | undefined {
+	return helpTopics.find((topic) => topic.id === id);
+}

--- a/web.svelte/src/lib/features/help/topics/admin.svelte
+++ b/web.svelte/src/lib/features/help/topics/admin.svelte
@@ -1,0 +1,20 @@
+<!--
+  Admin Help Topic Content
+-->
+
+<script lang="ts">
+	import Card from '$lib/components/ui/card.svelte';
+	import CardHeader from '$lib/components/ui/card-header.svelte';
+	import CardContent from '$lib/components/ui/card-content.svelte';
+</script>
+
+<Card>
+	<CardHeader>
+		<h2 class="text-lg font-semibold">Admin</h2>
+	</CardHeader>
+	<CardContent>
+		<p class="text-muted-foreground">
+			This section is a placeholder. Content will be added as the application evolves.
+		</p>
+	</CardContent>
+</Card>

--- a/web.svelte/src/lib/features/help/topics/api_keys.svelte
+++ b/web.svelte/src/lib/features/help/topics/api_keys.svelte
@@ -1,0 +1,20 @@
+<!--
+  API Keys Help Topic Content
+-->
+
+<script lang="ts">
+	import Card from '$lib/components/ui/card.svelte';
+	import CardHeader from '$lib/components/ui/card-header.svelte';
+	import CardContent from '$lib/components/ui/card-content.svelte';
+</script>
+
+<Card>
+	<CardHeader>
+		<h2 class="text-lg font-semibold">API Keys</h2>
+	</CardHeader>
+	<CardContent>
+		<p class="text-muted-foreground">
+			This section is a placeholder. Content will be added as the application evolves.
+		</p>
+	</CardContent>
+</Card>

--- a/web.svelte/src/lib/features/help/topics/faq.svelte
+++ b/web.svelte/src/lib/features/help/topics/faq.svelte
@@ -1,0 +1,20 @@
+<!--
+  FAQ Help Topic Content
+-->
+
+<script lang="ts">
+	import Card from '$lib/components/ui/card.svelte';
+	import CardHeader from '$lib/components/ui/card-header.svelte';
+	import CardContent from '$lib/components/ui/card-content.svelte';
+</script>
+
+<Card>
+	<CardHeader>
+		<h2 class="text-lg font-semibold">FAQ</h2>
+	</CardHeader>
+	<CardContent>
+		<p class="text-muted-foreground">
+			This section is a placeholder. Content will be added as the application evolves.
+		</p>
+	</CardContent>
+</Card>

--- a/web.svelte/src/lib/features/help/topics/getting_started.svelte
+++ b/web.svelte/src/lib/features/help/topics/getting_started.svelte
@@ -1,0 +1,20 @@
+<!--
+  Getting Started Help Topic Content
+-->
+
+<script lang="ts">
+	import Card from '$lib/components/ui/card.svelte';
+	import CardHeader from '$lib/components/ui/card-header.svelte';
+	import CardContent from '$lib/components/ui/card-content.svelte';
+</script>
+
+<Card>
+	<CardHeader>
+		<h2 class="text-lg font-semibold">Getting Started</h2>
+	</CardHeader>
+	<CardContent>
+		<p class="text-muted-foreground">
+			This section is a placeholder. Content will be added as the application evolves.
+		</p>
+	</CardContent>
+</Card>

--- a/web.svelte/src/lib/features/help/topics/sessions_security.svelte
+++ b/web.svelte/src/lib/features/help/topics/sessions_security.svelte
@@ -1,0 +1,20 @@
+<!--
+  Sessions & Security Help Topic Content
+-->
+
+<script lang="ts">
+	import Card from '$lib/components/ui/card.svelte';
+	import CardHeader from '$lib/components/ui/card-header.svelte';
+	import CardContent from '$lib/components/ui/card-content.svelte';
+</script>
+
+<Card>
+	<CardHeader>
+		<h2 class="text-lg font-semibold">Sessions & Security</h2>
+	</CardHeader>
+	<CardContent>
+		<p class="text-muted-foreground">
+			This section is a placeholder. Content will be added as the application evolves.
+		</p>
+	</CardContent>
+</Card>

--- a/web.svelte/src/routes/(app)/help/+page.svelte
+++ b/web.svelte/src/routes/(app)/help/+page.svelte
@@ -1,0 +1,138 @@
+<!--
+  Help Center Page
+
+  Main landing page for the Help Center feature. Displays a responsive
+  card grid of help topics and a Tools & Resources section with quick
+  links to API documentation and API key management.
+-->
+
+<script lang="ts">
+	import { goto } from '$app/navigation';
+	import { onMount } from 'svelte';
+	import { LifeBuoy, BookOpen, Key, Shield, ShieldCheck, HelpCircle, ArrowRight, Code2 } from 'lucide-svelte';
+	import { sitemapStore } from '$lib/stores/sitemap_store';
+	import webConfigStore from '$lib/config/web_config_store';
+	import Card from '$lib/components/ui/card.svelte';
+	import CardHeader from '$lib/components/ui/card-header.svelte';
+	import CardContent from '$lib/components/ui/card-content.svelte';
+	import Button from '$lib/components/ui/button.svelte';
+	import { helpTopics } from '$lib/features/help/help_topic_registry';
+
+	let apiBaseUrl = '';
+
+	onMount(async () => {
+		const config = await webConfigStore.getConfig();
+		apiBaseUrl = config.api.base_url;
+	});
+
+	// Resolve API keys href from sitemap
+	$: links = $sitemapStore.links;
+	$: templates = $sitemapStore.templates;
+	$: apiKeysHref = links?.['api-keys']?.href || templates?.['api-keys']?.target || null;
+
+	/**
+	 * Render the icon component for a given icon identifier.
+	 * Icons are handled inline rather than through a centralized mapper.
+	 */
+	const iconMap = {
+		'book-open': BookOpen,
+		'key': Key,
+		'shield': Shield,
+		'shield-check': ShieldCheck,
+		'help-circle': HelpCircle
+	} as const;
+</script>
+
+<div class="space-y-8">
+	<!-- Page Header -->
+	<div class="space-y-2">
+		<div class="flex items-center gap-3">
+			<div class="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
+				<LifeBuoy class="h-5 w-5 text-primary" />
+			</div>
+			<h1 class="text-3xl font-bold tracking-tight">Help Center</h1>
+		</div>
+		<p class="text-muted-foreground">
+			Find guides, references, and answers to common questions.
+		</p>
+	</div>
+
+	<!-- Topic Cards Grid -->
+	<div class="grid gap-4 grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
+		{#each helpTopics as topic (topic.id)}
+			{@const Icon = iconMap[topic.icon]}
+			<Card class="hover:shadow-md transition-shadow cursor-pointer" on:click={() => goto(`/help/${topic.id}`)}>
+				<CardHeader>
+					<div class="flex items-center gap-3">
+						<div class="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
+							<Icon class="h-5 w-5 text-primary" />
+						</div>
+						<h3 class="text-lg font-semibold">
+							{topic.title}
+						</h3>
+					</div>
+				</CardHeader>
+				<CardContent>
+					<p class="text-sm text-muted-foreground">{topic.description}</p>
+				</CardContent>
+			</Card>
+		{/each}
+	</div>
+
+	<!-- Tools & Resources -->
+	<div>
+		<h2 class="text-2xl font-semibold tracking-tight mb-4">Tools & Resources</h2>
+		<div class="grid gap-4 md:grid-cols-2">
+			{#if apiBaseUrl}
+				<Card class="hover:shadow-md transition-shadow">
+					<CardHeader>
+						<div class="flex items-center gap-3">
+							<div class="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
+								<Code2 class="h-5 w-5 text-primary" />
+							</div>
+							<h3 class="text-lg font-semibold">API Documentation</h3>
+						</div>
+					</CardHeader>
+					<CardContent class="space-y-3">
+						<p class="text-sm text-muted-foreground">
+							Explore the hypermedia API, endpoints, and response formats.
+						</p>
+						<Button
+							class="w-full"
+							variant="outline"
+							on:click={() => window.open(apiBaseUrl, '_blank', 'noopener,noreferrer')}
+						>
+							Open API Documentation
+							<ArrowRight class="ml-2 h-4 w-4" />
+						</Button>
+					</CardContent>
+				</Card>
+			{/if}
+
+			<Card class="hover:shadow-md transition-shadow">
+				<CardHeader>
+					<div class="flex items-center gap-3">
+						<div class="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
+							<Key class="h-5 w-5 text-primary" />
+						</div>
+						<h3 class="text-lg font-semibold">API Keys</h3>
+					</div>
+				</CardHeader>
+				<CardContent class="space-y-3">
+					<p class="text-sm text-muted-foreground">
+						Create and manage API keys for programmatic access to your resources.
+					</p>
+					<Button
+						class="w-full"
+						variant="outline"
+						disabled={!apiKeysHref}
+						on:click={() => apiKeysHref && goto(apiKeysHref)}
+					>
+						Manage API Keys
+						<ArrowRight class="ml-2 h-4 w-4" />
+					</Button>
+				</CardContent>
+			</Card>
+		</div>
+	</div>
+</div>

--- a/web.svelte/src/routes/(app)/help/[topicId]/+page.svelte
+++ b/web.svelte/src/routes/(app)/help/[topicId]/+page.svelte
@@ -1,0 +1,44 @@
+<!--
+  Help Topic Detail
+
+  Resolves the topic from the URL parameter and renders
+  the corresponding content component.
+-->
+
+<script lang="ts">
+	import { page } from '$app/stores';
+	import { goto } from '$app/navigation';
+	import { ArrowLeft } from 'lucide-svelte';
+	import Button from '$lib/components/ui/button.svelte';
+	import { getHelpTopicById } from '$lib/features/help/help_topic_registry';
+
+	$: topicId = $page.params.topicId;
+	$: topic = topicId ? getHelpTopicById(topicId) : undefined;
+</script>
+
+<div class="space-y-6">
+	<Button variant="ghost" class="gap-2" on:click={() => goto('/help')}>
+		<ArrowLeft class="h-4 w-4" />
+		Back to Help Center
+	</Button>
+
+	{#if topic}
+		{#await topic.load() then module}
+			<svelte:component this={module.default} />
+		{:catch}
+			<div class="text-center py-12">
+				<h2 class="text-2xl font-semibold tracking-tight">Failed to Load Topic</h2>
+				<p class="text-muted-foreground mt-2">
+					There was an error loading this help topic. Please try again.
+				</p>
+			</div>
+		{/await}
+	{:else}
+		<div class="text-center py-12">
+			<h2 class="text-2xl font-semibold tracking-tight">Topic Not Found</h2>
+			<p class="text-muted-foreground mt-2">
+				The help topic you are looking for does not exist.
+			</p>
+		</div>
+	{/if}
+</div>


### PR DESCRIPTION
## Summary
- Add Help Center feature to `web.svelte` (SvelteKit), adapted from the `web.shadcn` reference implementation
- Create file-based routes: `/help` (main page) and `/help/[topicId]` (topic detail)
- Add help topic registry with 5 placeholder topics (Getting Started, API Keys, Sessions & Security, Admin, FAQ)
- Create individual topic content as lazy-loaded Svelte components
- Add Tools & Resources section with API Documentation and API Keys links
- Enable the header Help button to navigate to `/help` (was disabled with "coming soon" tooltip)
- Remove the API Documentation link from the sidebar (now accessible via Help Center)

Story #15: Help Center — web.svelte

## Test plan
- [ ] Verify `/help` renders topic cards in a responsive grid (1/2/3 columns)
- [ ] Verify clicking a topic card navigates to `/help/{topicId}`
- [ ] Verify the back button on topic detail returns to `/help`
- [ ] Verify unknown topic IDs show "Topic Not Found"
- [ ] Verify the header Help button navigates to `/help`
- [ ] Verify API Documentation sidebar link is removed
- [ ] Verify Tools & Resources section shows API Documentation and API Keys links
- [ ] Verify `npm run build` passes