### PR TITLE
add refresh button animation to web.svelte

### DIFF
--- a/web.svelte/src/lib/components/api-keys/ApiKeysPage.svelte
+++ b/web.svelte/src/lib/components/api-keys/ApiKeysPage.svelte
@@ -24,6 +24,9 @@
 	// Optional refresh callback - called after bulk operations
 	export let onRefresh: (() => void) | undefined = undefined;
 
+	/** Whether a background refresh is in progress (spins the refresh icon) */
+	export let refreshing = false;
+
 	let createModalOpen = false;
 	let deleteModalOpen = false;
 	let selectedIds: string[] = [];
@@ -84,6 +87,7 @@
 	<HalCollectionList
 		resource={data}
 		onRefresh={onRefresh}
+		{refreshing}
 		onCreate={handleCreate}
 		bulkOperations={[
 			{

--- a/web.svelte/src/lib/components/hal_collection/HalCollectionList.svelte
+++ b/web.svelte/src/lib/components/hal_collection/HalCollectionList.svelte
@@ -31,6 +31,8 @@
 	export let emptyIcon: any = undefined;
 	export let showCreateButton = true;
 	export let showRefreshButton = true;
+	/** Whether a background refresh is in progress (spins the refresh icon) */
+	export let refreshing = false;
 	export let selectableFilter: ((item: HalObject) => boolean) | undefined = undefined;
 	/** Page title to display in the header row */
 	export let title: string | undefined = undefined;
@@ -138,8 +140,8 @@
 				</Button>
 			{/if}
 			{#if showRefreshButton}
-				<Button variant="outline" size="sm" on:click={handleRefresh}>
-					<RefreshCw class="w-4 h-4 mr-2" />
+				<Button variant="outline" size="sm" on:click={handleRefresh} disabled={refreshing}>
+					<RefreshCw class={cn("w-4 h-4 mr-2", refreshing && "animate-spin")} />
 					Refresh
 				</Button>
 			{/if}
@@ -220,8 +222,8 @@
 					</Button>
 				{/if}
 				{#if showRefreshButton}
-					<Button variant="outline" size="sm" on:click={handleRefresh}>
-						<RefreshCw class="w-4 h-4 mr-2" />
+					<Button variant="outline" size="sm" on:click={handleRefresh} disabled={refreshing}>
+						<RefreshCw class={cn("w-4 h-4 mr-2", refreshing && "animate-spin")} />
 						Refresh
 					</Button>
 				{/if}

--- a/web.svelte/src/lib/components/sessions/SessionsPage.svelte
+++ b/web.svelte/src/lib/components/sessions/SessionsPage.svelte
@@ -25,6 +25,9 @@
 	// Optional refresh callback - called after bulk operations
 	export let onRefresh: (() => void) | undefined = undefined;
 
+	/** Whether a background refresh is in progress (spins the refresh icon) */
+	export let refreshing = false;
+
 	// Extract userId from URL if present (e.g., /users/123/sessions or /users/123/sessions/list)
 	$: userIdFromUrl = $page.url.pathname.match(/^\/users\/([^\/]+)\/sessions/)?.[1];
 
@@ -133,6 +136,7 @@
 	<HalCollectionList
 		resource={data}
 		onRefresh={onRefresh}
+		{refreshing}
 		bulkOperations={[
 			{
 				id: 'delete',

--- a/web.svelte/src/lib/hooks/use_hal_resource.ts
+++ b/web.svelte/src/lib/hooks/use_hal_resource.ts
@@ -8,6 +8,8 @@ import { logger } from '$lib/logging';
 export interface HalResourceState<T extends HalObject = HalObject> {
 	data: T | null;
 	loading: boolean;
+	/** Whether a background refresh is in progress (data already loaded, re-fetching) */
+	refreshing: boolean;
 	error: Error | null;
 }
 
@@ -40,6 +42,7 @@ export function createHalResource<T extends HalObject = HalObject>(urlOrTemplate
 	const initialState: HalResourceState<T> = {
 		data: null,
 		loading: false,
+		refreshing: false,
 		error: null,
 	};
 
@@ -73,7 +76,7 @@ export function createHalResource<T extends HalObject = HalObject>(urlOrTemplate
 	}
 
 	async function fetch() {
-		update(state => ({ ...state, loading: true, error: null }));
+		update(state => ({ ...state, loading: true, refreshing: state.data !== null, error: null }));
 
 		try {
 			let data: HalObject;
@@ -139,6 +142,7 @@ export function createHalResource<T extends HalObject = HalObject>(urlOrTemplate
 				...state,
 				data: data as T,
 				loading: false,
+				refreshing: false,
 				error: null,
 			}));
 
@@ -152,6 +156,7 @@ export function createHalResource<T extends HalObject = HalObject>(urlOrTemplate
 			update(state => ({
 				...state,
 				loading: false,
+				refreshing: false,
 				error,
 			}));
 		}

--- a/web.svelte/src/routes/(app)/[...resource]/+page.svelte
+++ b/web.svelte/src/routes/(app)/[...resource]/+page.svelte
@@ -97,6 +97,7 @@
 	// Resource state
 	let resourceData: HalObject | null = null;
 	let resourceLoading = false;
+	let resourceRefreshing = false;
 	let resourceError: Error | null = null;
 
 	// Reactive: Create new resource store when path changes
@@ -121,6 +122,7 @@
 			unsubscribe = resourceStore.subscribe((state) => {
 				resourceData = state.data;
 				resourceLoading = state.loading;
+				resourceRefreshing = state.refreshing;
 				resourceError = state.error;
 
 				// Track resource in navigation history when loaded
@@ -256,7 +258,7 @@
 
 {#if DedicatedComponent && resourceData}
 	<!-- Dedicated component from registry - receives resource prop for HATEOAS compliance -->
-	<svelte:component this={DedicatedComponent} resource={resourceData} onRefresh={handleRefresh} />
+	<svelte:component this={DedicatedComponent} resource={resourceData} onRefresh={handleRefresh} refreshing={resourceRefreshing} />
 {:else if DedicatedComponent && resourceLoading}
 	<!-- Loading state for dedicated component -->
 	<div class="p-6">
@@ -277,6 +279,7 @@
 		<HalCollectionList
 			resource={resourceData}
 			onRefresh={handleRefresh}
+			refreshing={resourceRefreshing}
 			onCreate={handleCreate}
 			onRowClick={handleRowClick}
 		/>


### PR DESCRIPTION
## Summary
- Add `refreshing` state to `HalResourceState` in the `use_hal_resource` hook, set to `true` when data already exists and a re-fetch is in progress
- Add `refreshing` prop to `HalCollectionList.svelte` that spins the RefreshCw icon via `cn()` conditional class and disables the button
- Thread `refreshing` through `ApiKeysPage.svelte`, `SessionsPage.svelte`, and the generic `[...resource]/+page.svelte` route

## Test plan
- [ ] Navigate to API Keys page, click Refresh, verify the icon spins and button is disabled during fetch
- [ ] Navigate to Sessions page, click Refresh, verify the same animation behavior
- [ ] Navigate to a generic collection view, click Refresh, verify animation
- [ ] Verify initial page load does not show spinning (only background refresh triggers it)
- [ ] Verify `cd web.svelte && npm run build` passes