### PR TITLE
add theme system with auto, color themes, and settings page for web.svelte

### DIFF
--- a/web.svelte/src/app.css
+++ b/web.svelte/src/app.css
@@ -47,6 +47,96 @@
 		--input: 217.2 32.6% 17.5%;
 		--ring: 224.3 76.3% 48%;
 	}
+
+	/* Color Themes — dark variants with custom color palettes */
+
+	.midnight {
+		--background: 235 35% 5%;
+		--foreground: 226 100% 94%;
+		--card: 235 35% 7%;
+		--card-foreground: 226 100% 94%;
+		--popover: 235 35% 7%;
+		--popover-foreground: 226 100% 94%;
+		--primary: 263 70% 58%;
+		--primary-foreground: 226 100% 94%;
+		--secondary: 235 30% 15%;
+		--secondary-foreground: 226 100% 94%;
+		--muted: 235 30% 15%;
+		--muted-foreground: 230 20% 60%;
+		--accent: 263 50% 20%;
+		--accent-foreground: 226 100% 94%;
+		--destructive: 0 62.8% 30.6%;
+		--destructive-foreground: 226 100% 94%;
+		--border: 235 25% 18%;
+		--input: 235 25% 18%;
+		--ring: 263 70% 58%;
+	}
+
+	.emerald {
+		--background: 155 30% 4%;
+		--foreground: 152 80% 92%;
+		--card: 155 30% 6%;
+		--card-foreground: 152 80% 92%;
+		--popover: 155 30% 6%;
+		--popover-foreground: 152 80% 92%;
+		--primary: 160 60% 45%;
+		--primary-foreground: 155 30% 4%;
+		--secondary: 155 25% 13%;
+		--secondary-foreground: 152 80% 92%;
+		--muted: 155 25% 13%;
+		--muted-foreground: 155 15% 55%;
+		--accent: 160 40% 18%;
+		--accent-foreground: 152 80% 92%;
+		--destructive: 0 62.8% 30.6%;
+		--destructive-foreground: 152 80% 92%;
+		--border: 155 20% 16%;
+		--input: 155 20% 16%;
+		--ring: 160 60% 45%;
+	}
+
+	.sunset {
+		--background: 25 30% 5%;
+		--foreground: 35 80% 92%;
+		--card: 25 30% 7%;
+		--card-foreground: 35 80% 92%;
+		--popover: 25 30% 7%;
+		--popover-foreground: 35 80% 92%;
+		--primary: 38 70% 50%;
+		--primary-foreground: 25 30% 5%;
+		--secondary: 25 25% 14%;
+		--secondary-foreground: 35 80% 92%;
+		--muted: 25 25% 14%;
+		--muted-foreground: 30 15% 55%;
+		--accent: 38 40% 18%;
+		--accent-foreground: 35 80% 92%;
+		--destructive: 0 62.8% 30.6%;
+		--destructive-foreground: 35 80% 92%;
+		--border: 25 20% 17%;
+		--input: 25 20% 17%;
+		--ring: 38 70% 50%;
+	}
+
+	.charcoal {
+		--background: 0 0% 5%;
+		--foreground: 0 0% 92%;
+		--card: 0 0% 7%;
+		--card-foreground: 0 0% 92%;
+		--popover: 0 0% 7%;
+		--popover-foreground: 0 0% 92%;
+		--primary: 0 0% 60%;
+		--primary-foreground: 0 0% 5%;
+		--secondary: 0 0% 14%;
+		--secondary-foreground: 0 0% 92%;
+		--muted: 0 0% 14%;
+		--muted-foreground: 0 0% 55%;
+		--accent: 0 0% 18%;
+		--accent-foreground: 0 0% 92%;
+		--destructive: 0 62.8% 30.6%;
+		--destructive-foreground: 0 0% 92%;
+		--border: 0 0% 17%;
+		--input: 0 0% 17%;
+		--ring: 0 0% 60%;
+	}
 }
 
 @layer base {

--- a/web.svelte/src/lib/components/dashboard/app-header.svelte
+++ b/web.svelte/src/lib/components/dashboard/app-header.svelte
@@ -2,7 +2,6 @@
 	import { sidebarStore } from '$lib/stores/sidebar_store';
 	import { Menu, Search, HelpCircle, ChevronsLeft, ChevronsRight } from 'lucide-svelte';
 	import Breadcrumbs from './breadcrumbs.svelte';
-	import ThemeToggle from './theme-toggle.svelte';
 	import Button from '$lib/components/ui/button.svelte';
 	import { cn } from '$lib/utils';
 
@@ -70,8 +69,5 @@
 		>
 			<HelpCircle class="h-5 w-5" />
 		</Button>
-
-		<!-- Theme Toggle -->
-		<ThemeToggle />
 	</div>
 </header>

--- a/web.svelte/src/lib/components/dashboard/app-sidebar.svelte
+++ b/web.svelte/src/lib/components/dashboard/app-sidebar.svelte
@@ -15,7 +15,8 @@
 		BookOpen,
 		User,
 		LogOut,
-		ChevronRight
+		ChevronRight,
+		Settings
 	} from 'lucide-svelte';
 	import { toastStore } from '$lib/stores/toast_store';
 	import { cn } from '$lib/utils';
@@ -72,6 +73,7 @@
 	$: sessionsActive = currentPath === '/sessions';
 	$: apiKeysActive = currentPath === '/api-keys';
 	$: myProfileActive = currentPath === '/my-profile';
+	$: settingsActive = currentPath === '/settings';
 
 	// Split navigation: mainNav (all except My Account) and accountNav (My Account only)
 	$: mainNav = navigation.filter((item: { label: string }) => item.label !== 'My Account');
@@ -100,7 +102,7 @@
 
 	// Auto-expand My Account section when navigating to its child routes
 	$: {
-		if ((sessionsActive || apiKeysActive || myProfileActive) && !manuallyToggled['My Account']) {
+		if ((sessionsActive || apiKeysActive || myProfileActive || settingsActive) && !manuallyToggled['My Account']) {
 			if (!openMenuGroups['My Account']) {
 				openMenuGroups['My Account'] = true;
 				openMenuGroups = { ...openMenuGroups };
@@ -349,6 +351,22 @@
 								</button>
 							</li>
 						{/if}
+						<!-- Settings (client-side route, always present) -->
+						<li>
+							<button
+								on:click={() => navigate('/settings')}
+								disabled={settingsActive}
+								class={cn(
+									'w-full flex items-center justify-start gap-3 px-3 py-2 text-sm border-l-2 transition-colors',
+									settingsActive
+										? 'border-primary bg-accent text-accent-foreground font-medium cursor-default'
+										: 'border-border hover:bg-accent hover:text-accent-foreground'
+								)}
+							>
+								<Settings class="h-4 w-4" />
+								<span>Settings</span>
+							</button>
+						</li>
 						<!-- Logout (always present - client-side action) -->
 						<li>
 							<button

--- a/web.svelte/src/lib/stores/theme_store.ts
+++ b/web.svelte/src/lib/stores/theme_store.ts
@@ -1,0 +1,108 @@
+/**
+ * Theme Store
+ *
+ * Provides reactive theme state and persistence for light, dark, auto, and color theme modes.
+ * Auto mode resolves to light (6AM-5:59PM) or dark (6PM-5:59AM), re-evaluated every 15 minutes.
+ * Color themes (midnight, emerald, sunset, charcoal) apply both their named class and the
+ * dark class to document.documentElement so that existing dark: Tailwind utilities continue working.
+ *
+ * Uses localStorage to persist user preference across sessions.
+ */
+
+import { writable } from 'svelte/store';
+import { browser } from '$app/environment';
+
+export type Theme = 'dark' | 'light' | 'auto' | 'midnight' | 'emerald' | 'sunset' | 'charcoal';
+
+const STORAGE_KEY = 'ui-theme';
+const DEFAULT_THEME: Theme = 'auto';
+
+/** Color themes are dark variants that need both the dark class and their named class */
+const COLOR_THEMES: Theme[] = ['midnight', 'emerald', 'sunset', 'charcoal'];
+
+/** All theme classes that may be applied to document.documentElement */
+const ALL_THEME_CLASSES = ['light', 'dark', ...COLOR_THEMES] as const;
+
+/** Re-evaluation interval for auto mode (15 minutes) */
+const AUTO_INTERVAL_MS = 15 * 60 * 1000;
+
+/**
+ * Determine if the current time falls within daytime hours (6AM-5:59PM)
+ */
+function isDaytime(): boolean {
+	const hour = new Date().getHours();
+	return hour >= 6 && hour < 18;
+}
+
+/**
+ * Apply the correct classes to document.documentElement for the given theme
+ */
+function applyThemeClasses(theme: Theme): void {
+	if (!browser) return;
+
+	const root = window.document.documentElement;
+	root.classList.remove(...ALL_THEME_CLASSES);
+
+	if (theme === 'auto') {
+		root.classList.add(isDaytime() ? 'light' : 'dark');
+		return;
+	}
+
+	if (COLOR_THEMES.includes(theme)) {
+		// Color themes are dark variants — add both dark (for Tailwind dark: utilities)
+		// and the named class (for CSS variable overrides)
+		root.classList.add('dark', theme);
+		return;
+	}
+
+	root.classList.add(theme);
+}
+
+function createThemeStore() {
+	const initialTheme: Theme = browser
+		? (localStorage.getItem(STORAGE_KEY) as Theme) || DEFAULT_THEME
+		: DEFAULT_THEME;
+
+	const { subscribe, set } = writable<Theme>(initialTheme);
+
+	let autoInterval: ReturnType<typeof setInterval> | null = null;
+
+	function clearAutoInterval() {
+		if (autoInterval !== null) {
+			clearInterval(autoInterval);
+			autoInterval = null;
+		}
+	}
+
+	function setupAutoInterval() {
+		clearAutoInterval();
+		autoInterval = setInterval(() => {
+			applyThemeClasses('auto');
+		}, AUTO_INTERVAL_MS);
+	}
+
+	// Apply theme on initial load
+	if (browser) {
+		applyThemeClasses(initialTheme);
+		if (initialTheme === 'auto') {
+			setupAutoInterval();
+		}
+	}
+
+	return {
+		subscribe,
+		setTheme: (theme: Theme) => {
+			if (browser) {
+				localStorage.setItem(STORAGE_KEY, theme);
+			}
+			applyThemeClasses(theme);
+			clearAutoInterval();
+			if (theme === 'auto') {
+				setupAutoInterval();
+			}
+			set(theme);
+		},
+	};
+}
+
+export const themeStore = createThemeStore();

--- a/web.svelte/src/routes/(app)/settings/+page.svelte
+++ b/web.svelte/src/routes/(app)/settings/+page.svelte
@@ -1,0 +1,150 @@
+<!--
+  Settings Page
+
+  User-facing settings with theme/appearance controls.
+  Radio buttons for each theme option with label and description.
+  Core modes (Light, Dark, Auto) are separated from Color Themes by a divider.
+-->
+
+<script lang="ts">
+	import Card from '$lib/components/ui/card.svelte';
+	import CardHeader from '$lib/components/ui/card-header.svelte';
+	import CardContent from '$lib/components/ui/card-content.svelte';
+	import { themeStore, type Theme } from '$lib/stores/theme_store';
+	import { cn } from '$lib/utils';
+
+	interface ThemeOption {
+		value: Theme;
+		label: string;
+		description: string;
+	}
+
+	const CORE_MODES: ThemeOption[] = [
+		{ value: 'light', label: 'Light', description: 'Clean, bright interface' },
+		{ value: 'dark', label: 'Dark', description: 'Easy on the eyes' },
+		{ value: 'auto', label: 'Auto', description: 'Adjusts based on time of day' },
+	];
+
+	const COLOR_THEMES: ThemeOption[] = [
+		{ value: 'midnight', label: 'Midnight', description: 'Deep indigo with violet accents' },
+		{ value: 'emerald', label: 'Emerald', description: 'Forest green with mint accents' },
+		{ value: 'sunset', label: 'Sunset', description: 'Warm brown with amber accents' },
+		{ value: 'charcoal', label: 'Charcoal', description: 'True neutral gray, no color tint' },
+	];
+
+	function handleSelect(value: Theme) {
+		themeStore.setTheme(value);
+	}
+
+	$: currentTheme = $themeStore;
+</script>
+
+<div class="space-y-6">
+	<!-- Page Header -->
+	<div class="space-y-1">
+		<h1 class="text-3xl font-bold tracking-tight">Settings</h1>
+		<p class="text-muted-foreground">
+			Manage your application preferences
+		</p>
+	</div>
+
+	<!-- Appearance Section -->
+	<Card>
+		<CardHeader>
+			<h2 class="text-lg font-semibold leading-none tracking-tight">Appearance</h2>
+			<p class="text-sm text-muted-foreground">
+				Customize the look and feel of the application
+			</p>
+		</CardHeader>
+		<CardContent>
+			<div role="radiogroup" aria-label="Theme selection" class="space-y-6">
+				<!-- Core Modes -->
+				<div class="space-y-3">
+					{#each CORE_MODES as option (option.value)}
+						{@const selected = currentTheme === option.value}
+						{@const isRecommended = option.value === 'auto'}
+						<button
+							type="button"
+							role="radio"
+							aria-checked={selected}
+							on:click={() => handleSelect(option.value)}
+							class={cn(
+								'flex items-start gap-3 w-full rounded-lg border p-4 text-left transition-colors',
+								selected
+									? 'border-primary bg-primary/5'
+									: 'border-border hover:border-primary/40 hover:bg-accent/50'
+							)}
+						>
+							<div class="mt-0.5">
+								<div
+									class={cn(
+										'h-4 w-4 rounded-full border-2 flex items-center justify-center',
+										selected ? 'border-primary' : 'border-muted-foreground/40'
+									)}
+								>
+									{#if selected}
+										<div class="h-2 w-2 rounded-full bg-primary"></div>
+									{/if}
+								</div>
+							</div>
+							<div class="flex-1 space-y-1">
+								<span class="text-sm font-medium leading-none">
+									{option.label}
+									{#if isRecommended}
+										<span class="ml-2 text-xs text-muted-foreground font-normal">(Recommended)</span>
+									{/if}
+								</span>
+								<p class="text-sm text-muted-foreground">{option.description}</p>
+							</div>
+						</button>
+					{/each}
+				</div>
+
+				<!-- Divider -->
+				<div class="flex items-center gap-4">
+					<div class="flex-1 h-px bg-border"></div>
+					<span class="text-xs text-muted-foreground uppercase tracking-wider font-medium">Color Themes</span>
+					<div class="flex-1 h-px bg-border"></div>
+				</div>
+
+				<!-- Color Themes -->
+				<div class="space-y-3">
+					{#each COLOR_THEMES as option (option.value)}
+						{@const selected = currentTheme === option.value}
+						<button
+							type="button"
+							role="radio"
+							aria-checked={selected}
+							on:click={() => handleSelect(option.value)}
+							class={cn(
+								'flex items-start gap-3 w-full rounded-lg border p-4 text-left transition-colors',
+								selected
+									? 'border-primary bg-primary/5'
+									: 'border-border hover:border-primary/40 hover:bg-accent/50'
+							)}
+						>
+							<div class="mt-0.5">
+								<div
+									class={cn(
+										'h-4 w-4 rounded-full border-2 flex items-center justify-center',
+										selected ? 'border-primary' : 'border-muted-foreground/40'
+									)}
+								>
+									{#if selected}
+										<div class="h-2 w-2 rounded-full bg-primary"></div>
+									{/if}
+								</div>
+							</div>
+							<div class="flex-1 space-y-1">
+								<span class="text-sm font-medium leading-none">
+									{option.label}
+								</span>
+								<p class="text-sm text-muted-foreground">{option.description}</p>
+							</div>
+						</button>
+					{/each}
+				</div>
+			</div>
+		</CardContent>
+	</Card>
+</div>

--- a/web.svelte/src/routes/+layout.svelte
+++ b/web.svelte/src/routes/+layout.svelte
@@ -1,10 +1,14 @@
 <script lang="ts">
 	import '../app.css';
 	import { Toaster } from 'svelte-sonner';
-	import { ModeWatcher } from 'mode-watcher';
+	import { themeStore } from '$lib/stores/theme_store';
+
+	// Subscribe to theme store to keep it active for the lifetime of the app.
+	// The store applies theme classes to document.documentElement on initialization
+	// and on every change, so simply subscribing is sufficient.
+	$: void $themeStore;
 </script>
 
-<ModeWatcher />
 <Toaster richColors position="top-right" />
 
 <slot />

--- a/web.svelte/tailwind.config.ts
+++ b/web.svelte/tailwind.config.ts
@@ -4,7 +4,7 @@ import type { Config } from "tailwindcss";
 const config: Config = {
 	darkMode: ["class"],
 	content: ["./src/**/*.{html,js,svelte,ts}"],
-	safelist: ["dark"],
+	safelist: ["dark", "midnight", "emerald", "sunset", "charcoal"],
 	theme: {
 		container: {
 			center: true,


### PR DESCRIPTION
## Summary
- Replace `mode-watcher` with a custom Svelte store (`theme_store.ts`) supporting 7 theme modes: light, dark, auto, midnight, emerald, sunset, and charcoal
- Auto mode resolves to light (6AM-5:59PM) or dark (6PM-5:59AM), re-evaluated every 15 minutes via `setInterval`
- Color themes apply both their named CSS class and the `dark` class to `document.documentElement` so existing Tailwind `dark:` utilities continue working
- Add CSS variable definitions for all four color themes (midnight, emerald, sunset, charcoal) in `app.css`
- Add Settings/Appearance page at `/settings` with radio-button UI separated into Core Modes and Color Themes
- Remove ThemeToggle from app header
- Add Settings link to the My Account sidebar section (always present, client-side route)
- Theme preference persists in `localStorage` under `ui-theme`
- Safelist color theme classes in `tailwind.config.ts`

## Test plan
- [ ] Verify each theme (light, dark, auto, midnight, emerald, sunset, charcoal) applies correct CSS variables
- [ ] Verify auto mode switches between light/dark based on time of day
- [ ] Verify theme persists across page reloads via localStorage
- [ ] Verify Settings page is accessible from sidebar My Account section
- [ ] Verify ThemeToggle is no longer in the header
- [ ] Verify color themes add both `dark` and named class to `<html>` element
- [ ] Verify build passes: `cd web.svelte && npm run build`