### PR TITLE
Fix: Node.js engine version in root package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
         "./api.hypermedia"
     ],
     "engines": {
-        "node": ">=22.20.0",
+        "node": ">=20.10.0",
         "npm": ">=10.2.5"
     },
     "scripts": {


### PR DESCRIPTION
## Summary
- Corrects the `engines.node` field in the root `package.json` from `>=22.20.0` to `>=20.10.0`, aligning with the documented project requirement (Node.js >= 20.10.0).

## Test plan
- [ ] Verify `package.json` shows `"node": ">=20.10.0"` in the engines field.
- [ ] Confirm no other files are affected.