### PR TITLE
fix: conditional config copy and settings redirect bypass

### DIFF
--- a/api.hypermedia/package.json
+++ b/api.hypermedia/package.json
@@ -10,10 +10,10 @@
     "scripts": {
         "clean": "rimraf coverage build tmp dist",
         "prebuild": "echo 'Starting build...'",
-        "build": "tsc && tsc-alias && cp -r config dist/",
-        "build:prod": "tsc && tsc-alias && cp -r config dist/",
+        "build": "tsc && tsc-alias && [ -d config ] && cp -r config dist/ || true",
+        "build:prod": "tsc && tsc-alias && [ -d config ] && cp -r config dist/ || true",
         "build:watch": "tsc --watch --preserveWatchOutput & tsc-alias --watch",
-        "build:release": "npm run clean && tsc && tsc-alias && cp -r config dist/",
+        "build:release": "npm run clean && tsc && tsc-alias && [ -d config ] && cp -r config dist/ || true",
         "local": "npm run build && node dist/dev_server.js local 2>&1 | tee ../logs/api.log",
         "local:watch": "nodemon --watch src --watch ../core/dist --watch ../framework/dist --watch ../types/dist --exec \"npm run build && node dist/dev_server.js local\" --ext ts --delay 1 2>&1 | tee ../logs/api.log",
         "local:development": "npm run build && node dist/dev_server.js development",

--- a/web.daisyui/src/features/dashboard/dashboard.tsx
+++ b/web.daisyui/src/features/dashboard/dashboard.tsx
@@ -44,11 +44,12 @@ export const Dashboard = () => {
         if (isInitialLoad.current) {
             isInitialLoad.current = false;
 
-            // If initial load and not on dashboard or help, redirect
+            // If initial load and not on dashboard, help, or settings, redirect
             if (
                 location.pathname !== '/dashboard' &&
                 location.pathname !== '/' &&
-                !location.pathname.startsWith('/help')
+                !location.pathname.startsWith('/help') &&
+                !location.pathname.startsWith('/settings')
             ) {
                 navigate('/dashboard', { replace: true });
             }


### PR DESCRIPTION
## Summary
- **#33** — Make `api.hypermedia` build scripts resilient to a missing `config/` directory by using `[ -d config ] && cp -r config dist/ || true` instead of unconditional `cp -r config dist/`
- **#34** — Add `/settings` to the HATEOAS initial-load redirect bypass in `web.daisyui`, matching the existing `/help` exemption
- **#35** — `web.svelte` uses SvelteKit file-based routing with no equivalent redirect guard; `/settings` is already directly accessible via `(app)/settings/+page.svelte`

## Test plan
- [ ] `cd api.hypermedia && npm run build` succeeds when `config/` directory is absent
- [ ] In web.daisyui, navigating directly to `/settings` no longer redirects to `/dashboard`
- [ ] In web.svelte, `/settings` continues to render correctly on direct navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)